### PR TITLE
add github badge to landing page and a example button

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,36 @@ const graphicsObjects = getGraphicsObjectsFromLogString(logString)
 // Array<GraphicsObject>
 ```
 
+### Example Graphics JSON
+
+An example graphics JSON file is provided in the repository to help you get started quickly.
+
+You can find the example file at `site/src/examples/exampleGraphics.json`. This file contains a sample graphics object that you can use to test the functionality of the `graphics-debug` module.
+
+Here is the content of the `exampleGraphics.json` file:
+
+```JSON
+{
+  "title": "Example Usage",
+  "rects": [
+    {
+      "center": { "x": 0, "y": 0 },
+      "width": 100,
+      "height": 100,
+      "fill": "green"
+    }
+  ],
+  "points": [
+    {
+      "x": 50,
+      "y": 50,
+      "color": "red",
+      "label": "Test Output!"
+    }
+  ]
+}
 ```
 
-```
+You can load this example into the application to visualize the graphics objects and understand how the `graphics-debug` module works.
+
+

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ const graphicsObjects = getGraphicsObjectsFromLogString(logString)
 
 An example graphics JSON file is provided in the repository to help you get started quickly.
 
-You can find the example file at `site/src/examples/exampleGraphics.json`. This file contains a sample graphics object that you can use to test the functionality of the `graphics-debug` module.
+You can find the example file at [`site/examples/exampleGraphics.json`](site/examples/exampleGraphics.json). This file contains a sample graphics object that you can use to test the functionality of the `graphics-debug` module.
 
 Here is the content of the `exampleGraphics.json` file:
 

--- a/site/examples/exampleGraphics.json
+++ b/site/examples/exampleGraphics.json
@@ -1,0 +1,19 @@
+{
+  "title": "Example Usage",
+  "rects": [
+    {
+      "center": { "x": 0, "y": 0 },
+      "width": 100,
+      "height": 100,
+      "fill": "green"
+    }
+  ],
+  "points": [
+    {
+      "x": 50,
+      "y": 50,
+      "color": "red",
+      "label": "Test Output!"
+    }
+  ]
+}

--- a/site/pages/Home.tsx
+++ b/site/pages/Home.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react"
+import exampleGraphicsJson from "../examples/exampleGraphics.json"
 import {
   getSvgsFromLogString,
   getGraphicsObjectsFromLogString,
@@ -39,9 +40,21 @@ export default function Home() {
 
   return (
     <div className="space-y-8">
-      <div className="prose">
-        <h1>Graphics Debug Viewer</h1>
-        <p>Paste your debug output below to visualize graphics objects.</p>
+      <div className="flex justify-between items-start">
+        <div className="prose">
+          <h1>Graphics Debug Viewer</h1>
+          <p>Paste your debug output below to visualize graphics objects.</p>
+        </div>
+        <a
+          href="https://github.com/tscircuit/graphics-debug"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="https://img.shields.io/github/stars/tscircuit/graphics-debug?style=social"
+            alt="GitHub stars"
+          />
+        </a>
       </div>
       <form onSubmit={handleSubmit} className="space-y-4">
         <textarea
@@ -63,14 +76,12 @@ export default function Home() {
           </button>
           <button
             type="button"
-            onClick={() => {
-              setInput(
-                `:graphics {"title":"Example Usage","rects":[{"center":{"x":0,"y":0},"width":100,"height":100,"color":"green"}],"points":[{"x":50,"y":50,"color":"red","label":"Test Output!"}]} :graphics {"title":"More Example Usage","lines":[{"points":[{"x":0,"y":0},{"x":5,"y":5}]}],"circles":[{"center":{"x":2.5,"y":2.5},"radius":2.5,"color":"blue"}],"points":[{"x":10,"y":10,"color":"red","label":"B"}]}`,
-              )
-            }}
+            onClick={() =>
+              setInput(`:graphics ${JSON.stringify(exampleGraphicsJson)}`)
+            }
             className="px-4 py-2 bg-gray-600 text-white rounded hover:bg-gray-700"
           >
-            See Example
+            Load Example
           </button>
         </div>
       </form>


### PR DESCRIPTION
/claim #15
Fixes #15 

- [x] Add github badge
- [x] Add example graphics debug json file
- [ ] NPM Package
#### screenshots:

https://github.com/user-attachments/assets/b18489b5-933a-4a8a-954d-f50170dee2c3

![Screenshot from 2025-01-29 22-59-17](https://github.com/user-attachments/assets/1db2e431-9740-411a-9ac0-0fd18fea7dfe)


