### PR TITLE
Add graphics stacking utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,17 @@ import { mergeGraphics } from "graphics-debug"
 const combined = mergeGraphics(graphicsObjectA, graphicsObjectB)
 ```
 
+### Stack GraphicsObjects
+
+Use `stackGraphicsHorizontally` or `stackGraphicsVertically` to place graphics next to or above each other.
+
+```tsx
+import { stackGraphicsHorizontally, stackGraphicsVertically } from "graphics-debug"
+
+const sideBySide = stackGraphicsHorizontally([graphicsObjectA, graphicsObjectB])
+const stacked = stackGraphicsVertically([graphicsObjectA, graphicsObjectB])
+```
+
 ### Testing GraphicsObjects with Bun's Test Framework
 
 If you're using Bun for testing, you can use the `toMatchGraphicsSvg` matcher to compare graphics objects against saved snapshots.

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -7,6 +7,10 @@ import {
 } from "./drawGraphicsToCanvas"
 import { translateGraphics } from "./translateGraphics"
 import { mergeGraphics } from "./mergeGraphics"
+import {
+  stackGraphicsHorizontally,
+  stackGraphicsVertically,
+} from "./stackGraphics"
 
 export type {
   Point,
@@ -29,6 +33,10 @@ export {
 } from "./drawGraphicsToCanvas"
 export { translateGraphics } from "./translateGraphics"
 export { mergeGraphics } from "./mergeGraphics"
+export {
+  stackGraphicsHorizontally,
+  stackGraphicsVertically,
+} from "./stackGraphics"
 export { FONT_SIZE_WIDTH_RATIO, FONT_SIZE_HEIGHT_RATIO } from "./constants"
 
 export function getSvgFromLogString(logString: string): string {

--- a/lib/stackGraphics.ts
+++ b/lib/stackGraphics.ts
@@ -1,0 +1,49 @@
+export { stackGraphicsHorizontally, stackGraphicsVertically }
+import type { GraphicsObject } from "./types"
+import { getBounds } from "./drawGraphicsToCanvas"
+import { translateGraphics } from "./translateGraphics"
+import { mergeGraphics } from "./mergeGraphics"
+
+function stackGraphicsHorizontally(
+  graphicsList: GraphicsObject[],
+): GraphicsObject {
+  if (graphicsList.length === 0) return {}
+  let result = graphicsList[0]
+  let prevBounds = getBounds(result)
+  const baseMinY = prevBounds.minY
+  for (let i = 1; i < graphicsList.length; i++) {
+    const g = graphicsList[i]
+    const bounds = getBounds(g)
+    const prevWidth = prevBounds.maxX - prevBounds.minX
+    const width = bounds.maxX - bounds.minX
+    const padding = (prevWidth + width) / 8
+    const dx = prevBounds.maxX + padding - bounds.minX
+    const dy = baseMinY - bounds.minY
+    const shifted = translateGraphics(g, dx, dy)
+    result = mergeGraphics(result, shifted)
+    prevBounds = getBounds(shifted)
+  }
+  return result
+}
+
+function stackGraphicsVertically(
+  graphicsList: GraphicsObject[],
+): GraphicsObject {
+  if (graphicsList.length === 0) return {}
+  let result = graphicsList[0]
+  let prevBounds = getBounds(result)
+  const baseMinX = prevBounds.minX
+  for (let i = 1; i < graphicsList.length; i++) {
+    const g = graphicsList[i]
+    const bounds = getBounds(g)
+    const prevHeight = prevBounds.maxY - prevBounds.minY
+    const height = bounds.maxY - bounds.minY
+    const padding = (prevHeight + height) / 8
+    const dx = baseMinX - bounds.minX
+    const dy = prevBounds.maxY + padding - bounds.minY
+    const shifted = translateGraphics(g, dx, dy)
+    result = mergeGraphics(result, shifted)
+    prevBounds = getBounds(shifted)
+  }
+  return result
+}

--- a/tests/stackGraphics.test.ts
+++ b/tests/stackGraphics.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+import {
+  stackGraphicsHorizontally,
+  stackGraphicsVertically,
+} from "../lib/stackGraphics"
+import type { GraphicsObject } from "../lib/types"
+
+const rectGraphic = (): GraphicsObject => ({
+  rects: [{ center: { x: 0, y: 0 }, width: 2, height: 2 }],
+})
+
+describe("stackGraphicsHorizontally", () => {
+  test("stacks two graphics side by side", () => {
+    const g1 = rectGraphic()
+    const g2 = rectGraphic()
+    const stacked = stackGraphicsHorizontally([g1, g2])
+    expect(stacked.rects?.length).toBe(2)
+    const [r1, r2] = stacked.rects!
+    expect(r1.center.x).toBeCloseTo(0)
+    expect(r2.center.x).toBeCloseTo(2.5)
+  })
+})
+
+describe("stackGraphicsVertically", () => {
+  test("stacks two graphics vertically", () => {
+    const g1 = rectGraphic()
+    const g2 = rectGraphic()
+    const stacked = stackGraphicsVertically([g1, g2])
+    expect(stacked.rects?.length).toBe(2)
+    const [r1, r2] = stacked.rects!
+    expect(r1.center.y).toBeCloseTo(0)
+    expect(r2.center.y).toBeCloseTo(2.5)
+  })
+})


### PR DESCRIPTION
## Summary
- add `stackGraphicsHorizontally` and `stackGraphicsVertically` to combine graphics by translation
- export the new helpers from the library
- document how to stack graphics in README
- add tests for the new stacking utilities

## Testing
- `bun test tests/stackGraphics.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_685f0254e600832e9f50c72a2d08b561