### PR TITLE
Add gap options to createGraphicsGrid

### DIFF
--- a/lib/stackGraphics.ts
+++ b/lib/stackGraphics.ts
@@ -54,7 +54,12 @@ function stackGraphicsVertically(
 
 function createGraphicsGrid(
   graphicsRows: GraphicsObject[][],
-  opts: { cellWidth?: number; cellHeight?: number } = {},
+  opts: {
+    cellWidth?: number
+    cellHeight?: number
+    gap?: number
+    gapAsCellWidthFraction?: number
+  } = {},
 ): GraphicsObject {
   if (graphicsRows.length === 0 || graphicsRows[0].length === 0) return {}
 
@@ -70,6 +75,11 @@ function createGraphicsGrid(
 
   const cellWidth = opts.cellWidth ?? maxWidth
   const cellHeight = opts.cellHeight ?? maxHeight
+  const gap =
+    opts.gap ??
+    (opts.gapAsCellWidthFraction !== undefined
+      ? opts.gapAsCellWidthFraction * cellWidth
+      : 0)
 
   let result: GraphicsObject | null = null
 
@@ -78,8 +88,8 @@ function createGraphicsGrid(
     for (let c = 0; c < row.length; c++) {
       const g = row[c]
       const b = getBounds(g)
-      const dx = c * cellWidth - b.minX
-      const dy = r * cellHeight - b.minY
+      const dx = c * (cellWidth + gap) - b.minX
+      const dy = r * (cellHeight + gap) - b.minY
       const shifted = translateGraphics(g, dx, dy)
       result = result ? mergeGraphics(result, shifted) : shifted
     }

--- a/tests/stackGraphics.test.ts
+++ b/tests/stackGraphics.test.ts
@@ -52,4 +52,34 @@ describe("createGraphicsGrid", () => {
     expect(r4.center.x).toBeCloseTo(3)
     expect(r4.center.y).toBeCloseTo(3)
   })
+
+  test("supports a gap between cells", () => {
+    const g = rectGraphic()
+    const grid = createGraphicsGrid(
+      [
+        [g, g],
+        [g, g],
+      ],
+      { gap: 1 },
+    )
+    const [r1, r2, r3, r4] = grid.rects!
+    expect(r1.center.x).toBeCloseTo(1)
+    expect(r2.center.x).toBeCloseTo(4)
+    expect(r3.center.y).toBeCloseTo(4)
+    expect(r4.center.x).toBeCloseTo(4)
+    expect(r4.center.y).toBeCloseTo(4)
+  })
+
+  test("supports a gap as a fraction of the cell width", () => {
+    const g = rectGraphic()
+    const grid = createGraphicsGrid(
+      [
+        [g, g],
+        [g, g],
+      ],
+      { gapAsCellWidthFraction: 0.5 },
+    )
+    const [r1, r2] = grid.rects!
+    expect(r2.center.x).toBeCloseTo(4)
+  })
 })


### PR DESCRIPTION
## Summary
- allow specifying gaps when generating graphics grids
- support gap fraction relative to cell width
- test new gap options

## Testing
- `bun test tests/stackGraphics.test.ts`
- `bun test tests`

------
https://chatgpt.com/codex/tasks/task_b_685f198eea60832ebaea1216c8dfbf49