### PR TITLE
Adjust font size for rect labels

### DIFF
--- a/lib/getSvgFromGraphicsObject.ts
+++ b/lib/getSvgFromGraphicsObject.ts
@@ -293,7 +293,10 @@ export function getSvgFromGraphicsObject(
                       x: (rectX + 5).toString(),
                       y: (rectY - 5).toString(), // Position above the top-left corner
                       "font-family": "sans-serif",
-                      "font-size": "12",
+                      "font-size": (
+                        ((scaledWidth + scaledHeight) / 2) *
+                        0.02
+                      ).toString(),
                       fill: rect.stroke || "black", // Default to stroke color for label
                     },
                     children: [{ type: "text", value: rect.label }],

--- a/tests/getSvgFromGraphicsObject.test.ts
+++ b/tests/getSvgFromGraphicsObject.test.ts
@@ -77,6 +77,34 @@ describe("getSvgFromGraphicsObject", () => {
     expect(svg).toMatchSvgSnapshot(import.meta.path, "rectangles")
   })
 
+  test("rect label font size scales with dimensions", () => {
+    const input: GraphicsObject = {
+      rects: [
+        {
+          center: { x: 0, y: 0 },
+          width: 50,
+          height: 50,
+          stroke: "black",
+          fill: "none",
+          label: "R",
+        },
+      ],
+    }
+
+    const svg = getSvgFromGraphicsObject(input, { includeTextLabels: true })
+    const rectMatch = svg.match(
+      /<rect[^>]*width="([0-9.]+)"[^>]*height="([0-9.]+)"/,
+    )
+    const textMatch = svg.match(/<text[^>]*font-size="([0-9.]+)"/)
+    expect(rectMatch).toBeTruthy()
+    expect(textMatch).toBeTruthy()
+    const width = parseFloat(rectMatch![1])
+    const height = parseFloat(rectMatch![2])
+    const fontSize = parseFloat(textMatch![1])
+    const expected = ((width + height) / 2) * 0.02
+    expect(fontSize).toBeCloseTo(expected)
+  })
+
   test("should generate SVG with circles", () => {
     const input: GraphicsObject = {
       circles: [


### PR DESCRIPTION
## Summary
- calculate a dynamic font size for rectangle labels
- test label font sizing

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/getSvgFromGraphicsObject.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_685f3ca1b4e0832eb4c0a9d440f2eb1b