### PR TITLE
Align rect labels and bump @types/bun

### DIFF
--- a/lib/getSvgFromGraphicsObject.ts
+++ b/lib/getSvgFromGraphicsObject.ts
@@ -291,11 +291,12 @@ export function getSvgFromGraphicsObject(
                     type: "element",
                     attributes: {
                       x: (rectX + 5).toString(),
-                      y: (rectY - 5).toString(), // Position above the top-left corner
+                      y: rectY.toString(),
                       "font-family": "sans-serif",
+                      "dominant-baseline": "text-before-edge",
                       "font-size": (
                         ((scaledWidth + scaledHeight) / 2) *
-                        0.02
+                        0.06
                       ).toString(),
                       fill: rect.stroke || "black", // Default to stroke color for label
                     },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@react-hook/resize-observer": "^2.0.2",
-    "@types/bun": "latest",
+    "@types/bun": "^1.2.17",
     "@types/debug": "^4.1.12",
     "@types/jsdom": "^21.1.7",
     "@types/pretty": "^2.0.3",

--- a/tests/getSvgFromGraphicsObject.test.ts
+++ b/tests/getSvgFromGraphicsObject.test.ts
@@ -101,7 +101,7 @@ describe("getSvgFromGraphicsObject", () => {
     const width = parseFloat(rectMatch![1])
     const height = parseFloat(rectMatch![2])
     const fontSize = parseFloat(textMatch![1])
-    const expected = ((width + height) / 2) * 0.02
+    const expected = ((width + height) / 2) * 0.06
     expect(fontSize).toBeCloseTo(expected)
   })
 


### PR DESCRIPTION
## Summary
- align rectangle label text to top of rect
- make rect labels 3x larger
- update rect label test expectation
- update @types/bun

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test`


------
https://chatgpt.com/codex/tasks/task_b_685f3f1a63f0832e8ffa791acbc9b681