### PR TITLE
Fix graphics grid row order

### DIFF
--- a/lib/stackGraphics.ts
+++ b/lib/stackGraphics.ts
@@ -90,7 +90,7 @@ function createGraphicsGrid(
       const g = row[c]
       const b = getBounds(g)
       const dx = c * (cellWidth + gap) - b.minX
-      const dy = r * (cellHeight + gap) - b.minY
+      const dy = -r * (cellHeight + gap) - b.minY
       const shifted = translateGraphics(g, dx, dy)
       result = result ? mergeGraphics(result, shifted) : shifted
     }

--- a/tests/stackGraphics.test.ts
+++ b/tests/stackGraphics.test.ts
@@ -48,9 +48,9 @@ describe("createGraphicsGrid", () => {
     expect(r2.center.x).toBeCloseTo(3)
     expect(r2.center.y).toBeCloseTo(1)
     expect(r3.center.x).toBeCloseTo(1)
-    expect(r3.center.y).toBeCloseTo(3)
+    expect(r3.center.y).toBeCloseTo(-1)
     expect(r4.center.x).toBeCloseTo(3)
-    expect(r4.center.y).toBeCloseTo(3)
+    expect(r4.center.y).toBeCloseTo(-1)
   })
 
   test("supports a gap between cells", () => {
@@ -65,9 +65,9 @@ describe("createGraphicsGrid", () => {
     const [r1, r2, r3, r4] = grid.rects!
     expect(r1.center.x).toBeCloseTo(1)
     expect(r2.center.x).toBeCloseTo(4)
-    expect(r3.center.y).toBeCloseTo(4)
+    expect(r3.center.y).toBeCloseTo(-2)
     expect(r4.center.x).toBeCloseTo(4)
-    expect(r4.center.y).toBeCloseTo(4)
+    expect(r4.center.y).toBeCloseTo(-2)
   })
 
   test("supports a gap as a fraction of the cell width", () => {


### PR DESCRIPTION
## Summary
- fix the Y offset when creating a graphics grid so rows are not reversed
- update tests for new grid orientation

## Testing
- `bun run format`
- `bun test`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/stackGraphics.test.ts`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/getSvgFromGraphicsObject.test.ts`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/toMatchGraphicsSvg.test.ts`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/SVGRenderer.test.tsx`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/getGraphicsObjectsFromLogString.test.ts`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/mergeGraphics.test.ts`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/getBounds.test.ts`
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/translateGraphics.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_685f3ed7e5fc832e8d19a9aa32f345ec