### PR TITLE
Change includeTextLabels default

### DIFF
--- a/lib/getSvgFromGraphicsObject.ts
+++ b/lib/getSvgFromGraphicsObject.ts
@@ -114,7 +114,7 @@ function projectPoint(point: Point, matrix: Matrix) {
 export function getSvgFromGraphicsObject(
   graphics: GraphicsObject,
   {
-    includeTextLabels = true,
+    includeTextLabels = false,
     backgroundColor,
     svgWidth = DEFAULT_SVG_SIZE,
     svgHeight = DEFAULT_SVG_SIZE,

--- a/tests/__snapshots__/points.snap.svg
+++ b/tests/__snapshots__/points.snap.svg
@@ -1,9 +1,9 @@
 <svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
   <g>
-    <circle data-type="point" data-label="A" data-x="0" data-y="0" cx="40" cy="600" r="3" fill="red" /><text x="45" y="595" font-family="sans-serif" font-size="12">A</text>
+    <circle data-type="point" data-label="A" data-x="0" data-y="0" cx="40" cy="600" r="3" fill="red" />
   </g>
   <g>
-    <circle data-type="point" data-label="B" data-x="1" data-y="1" cx="600" cy="40" r="3" fill="blue" /><text x="605" y="35" font-family="sans-serif" font-size="12">B</text>
+    <circle data-type="point" data-label="B" data-x="1" data-y="1" cx="600" cy="40" r="3" fill="blue" />
   </g>
   <g id="crosshair" style="display: none">
     <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />

--- a/tests/getSvgFromGraphicsObject.test.ts
+++ b/tests/getSvgFromGraphicsObject.test.ts
@@ -18,9 +18,22 @@ describe("getSvgFromGraphicsObject", () => {
     expect(svg).toContain('height="640"')
     expect(svg).toContain('fill="red"')
     expect(svg).toContain('fill="blue"')
+    expect(svg).not.toContain(">A<")
+    expect(svg).not.toContain(">B<")
+    expect(svg).toMatchSvgSnapshot(import.meta.path, "points")
+  })
+
+  test("includes point labels when includeTextLabels is true", () => {
+    const input: GraphicsObject = {
+      points: [
+        { x: 0, y: 0, label: "A", color: "red" },
+        { x: 1, y: 1, label: "B", color: "blue" },
+      ],
+    }
+
+    const svg = getSvgFromGraphicsObject(input, { includeTextLabels: true })
     expect(svg).toContain(">A<")
     expect(svg).toContain(">B<")
-    expect(svg).toMatchSvgSnapshot(import.meta.path, "points")
   })
 
   test("should generate SVG with lines and custom stroke properties", () => {


### PR DESCRIPTION
## Summary
- default `includeTextLabels` to `false`
- adjust tests for new behaviour
- update point snapshot

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/getSvgFromGraphicsObject.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_6861750c540c832eb79fc4c4e5eb5b6f