### PR TITLE
Add titles option for vertical stacking

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,10 @@ const sideBySide = stackGraphicsHorizontally([
   graphicsObjectA,
   graphicsObjectB,
 ], { titles: ["A", "B"] })
-const stacked = stackGraphicsVertically([graphicsObjectA, graphicsObjectB])
+const stacked = stackGraphicsVertically([
+  graphicsObjectA,
+  graphicsObjectB,
+], { titles: ["A", "B"] })
 ```
 
 ### Testing GraphicsObjects with Bun's Test Framework

--- a/lib/stackGraphics.ts
+++ b/lib/stackGraphics.ts
@@ -53,11 +53,13 @@ function stackGraphicsHorizontally(
 
 function stackGraphicsVertically(
   graphicsList: GraphicsObject[],
+  opts: { titles?: string[] } = {},
 ): GraphicsObject {
   if (graphicsList.length === 0) return {}
   let result = graphicsList[0]
   let prevBounds = getBounds(result)
   const baseMinX = prevBounds.minX
+  const boundsList = [prevBounds]
   for (let i = 1; i < graphicsList.length; i++) {
     const g = graphicsList[i]
     const bounds = getBounds(g)
@@ -69,6 +71,23 @@ function stackGraphicsVertically(
     const shifted = translateGraphics(g, dx, dy)
     result = mergeGraphics(result, shifted)
     prevBounds = getBounds(shifted)
+    boundsList.push(prevBounds)
+  }
+  if (opts.titles && opts.titles.length > 0) {
+    const overall = getBounds(result)
+    const totalHeight = overall.maxY - overall.minY
+    const fontSize = totalHeight * 0.025
+    const texts = opts.titles.slice(0, boundsList.length).map((title, idx) => {
+      const b = boundsList[idx]
+      return {
+        x: b.minX - fontSize,
+        y: b.maxY,
+        text: title,
+        fontSize,
+        anchorSide: "top_right" as const,
+      }
+    })
+    result = mergeGraphics(result, { texts })
   }
   return result
 }

--- a/tests/__snapshots__/vertical-titles.snap.svg
+++ b/tests/__snapshots__/vertical-titles.snap.svg
@@ -1,0 +1,65 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xmlns="http://www.w3.org/2000/svg">
+  <g>
+    <rect data-type="rect" data-label="" data-x="0" data-y="0" x="217.71273712737127" y="53.65853658536582" width="242.81842818428186" height="242.81842818428186" fill="lightblue" stroke="black" stroke-width="0.008236607142857143" />
+  </g>
+  <g>
+    <rect data-type="rect" data-label="" data-x="0" data-y="-2.5" x="217.71273712737127" y="357.18157181571814" width="242.81842818428186" height="242.81842818428186" fill="lightblue" stroke="black" stroke-width="0.008236607142857143" />
+  </g><text data-type="text" data-label="One" data-x="-1.1125" data-y="1" x="204.05420054200542" y="53.65853658536582" fill="black" font-size="13.658536585365855" font-family="sans-serif" text-anchor="end" dominant-baseline="text-before-edge">One</text><text data-type="text" data-label="Two" data-x="-1.1125" data-y="-1.5" x="204.05420054200542" y="357.18157181571814" fill="black" font-size="13.658536585365855" font-family="sans-serif" text-anchor="end" dominant-baseline="text-before-edge">Two</text>
+  <g id="crosshair" style="display: none">
+    <line id="crosshair-h" y1="0" y2="640" stroke="#666" stroke-width="0.5" />
+    <line id="crosshair-v" x1="0" x2="640" stroke="#666" stroke-width="0.5" /><text id="coordinates" font-family="monospace" font-size="12" fill="#666"></text>
+  </g>
+  <script>
+    <![CDATA[
+    document.currentScript.parentElement.addEventListener('mousemove', (e) => {
+      const svg = e.currentTarget;
+      const rect = svg.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      const crosshair = svg.getElementById('crosshair');
+      const h = svg.getElementById('crosshair-h');
+      const v = svg.getElementById('crosshair-v');
+      const coords = svg.getElementById('coordinates');
+
+      crosshair.style.display = 'block';
+      h.setAttribute('x1', '0');
+      h.setAttribute('x2', '640');
+      h.setAttribute('y1', y);
+      h.setAttribute('y2', y);
+      v.setAttribute('x1', x);
+      v.setAttribute('x2', x);
+      v.setAttribute('y1', '0');
+      v.setAttribute('y2', '640');
+
+      // Calculate real coordinates using inverse transformation
+      const matrix = {
+        "a": 121.40921409214093,
+        "c": 0,
+        "e": 339.1219512195122,
+        "b": 0,
+        "d": -121.40921409214093,
+        "f": 175.06775067750675
+      };
+      // Manually invert and apply the affine transform
+      // Since we only use translate and scale, we can directly compute:
+      // x' = (x - tx) / sx
+      // y' = (y - ty) / sy
+      const sx = matrix.a;
+      const sy = matrix.d;
+      const tx = matrix.e;
+      const ty = matrix.f;
+      const realPoint = {
+        x: (x - tx) / sx,
+        y: (y - ty) / sy // Flip y back since we used negative scale
+      }
+
+      coords.textContent = `(${realPoint.x.toFixed(2)}, ${realPoint.y.toFixed(2)})`;
+      coords.setAttribute('x', (x + 5).toString());
+      coords.setAttribute('y', (y - 5).toString());
+    });
+    document.currentScript.parentElement.addEventListener('mouseleave', () => {
+      document.currentScript.parentElement.getElementById('crosshair').style.display = 'none';
+    });
+    ]]>
+  </script>
+</svg>

--- a/tests/stackGraphics.test.ts
+++ b/tests/stackGraphics.test.ts
@@ -53,6 +53,18 @@ describe("stackGraphicsVertically", () => {
     expect(r1.center.y).toBeCloseTo(0)
     expect(r2.center.y).toBeCloseTo(-2.5)
   })
+
+  test("adds titles to the left of each graphic", async () => {
+    const g1 = rectGraphic()
+    const g2 = rectGraphic()
+    const stacked = stackGraphicsVertically([g1, g2], {
+      titles: ["One", "Two"],
+    })
+
+    await expect(stacked).toMatchGraphicsSvg(import.meta.path, {
+      svgName: "vertical-titles",
+    })
+  })
 })
 
 describe("createGraphicsGrid", () => {


### PR DESCRIPTION
## Summary
- allow `stackGraphicsVertically` to accept a `{ titles: string[] }` option
- display titles left of each stacked graphic
- document the new option in README
- test snapshot for vertical titles

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests/stackGraphics.test.ts`
- `bun run format`

------
https://chatgpt.com/codex/tasks/task_b_6864b3a67cd4832e935d518d81211c72