### PR TITLE
Ensure small rectangles render above larger ones

### DIFF
--- a/site/components/InteractiveGraphics/InteractiveGraphics.tsx
+++ b/site/components/InteractiveGraphics/InteractiveGraphics.tsx
@@ -17,6 +17,7 @@ import { Rect } from "./Rect"
 import { Circle } from "./Circle"
 import { Text } from "./Text"
 import { getGraphicsBounds } from "site/utils/getGraphicsBounds"
+import { sortRectsByArea } from "site/utils/sortRectsByArea"
 import {
   useIsPointOnScreen,
   useDoesLineIntersectViewport,
@@ -347,7 +348,7 @@ export const InteractiveGraphics = ({
     [graphics.lines, filterLines, objectLimit],
   )
   const filteredRects = useMemo(
-    () => filterAndLimit(graphics.rects, filterRects),
+    () => sortRectsByArea(filterAndLimit(graphics.rects, filterRects)),
     [graphics.rects, filterRects, objectLimit],
   )
   const filteredPoints = useMemo(

--- a/site/utils/sortRectsByArea.ts
+++ b/site/utils/sortRectsByArea.ts
@@ -1,0 +1,5 @@
+import type { Rect } from "lib/types"
+
+// Sort rectangles so larger ones render first so smaller ones appear on top
+export const sortRectsByArea = <T extends Rect>(rects: T[]): T[] =>
+  rects.slice().sort((a, b) => b.width * b.height - a.width * a.height)

--- a/tests/sortRectsByArea.test.ts
+++ b/tests/sortRectsByArea.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test"
+import { sortRectsByArea } from "site/utils/sortRectsByArea"
+import type { Rect } from "lib/types"
+
+describe("sortRectsByArea", () => {
+  test("orders rectangles so smaller ones come last", () => {
+    const rects: Rect[] = [
+      { center: { x: 0, y: 0 }, width: 10, height: 10 },
+      { center: { x: 0, y: 0 }, width: 5, height: 5 },
+      { center: { x: 0, y: 0 }, width: 20, height: 20 },
+    ]
+
+    const sorted = sortRectsByArea(rects)
+    const areas = sorted.map((r) => r.width * r.height)
+    expect(areas).toEqual([400, 100, 25])
+  })
+})


### PR DESCRIPTION
## Summary
- sort rectangles by area before rendering so smaller ones appear on top when overlapping
- add utility and tests for sorting rectangles by area

## Testing
- `bun test tests/sortRectsByArea.test.ts`
- `bun test tests`

------
https://chatgpt.com/codex/tasks/task_b_68b909cc2a0c832e80cff85a8b290c27