### PR TITLE
fix: keep dimension hotkey active

### DIFF
--- a/site/components/DimensionOverlay.tsx
+++ b/site/components/DimensionOverlay.tsx
@@ -53,8 +53,14 @@ export const DimensionOverlay: React.FC<Props> = ({ children, transform }) => {
       container.addEventListener("blur", removeKeyListener)
       container.addEventListener("mouseenter", addKeyListener)
       container.addEventListener("mouseleave", removeKeyListener)
+
+      // Ensure the key listener is active immediately so the "d" hotkey
+      // works without requiring a mouse enter/leave cycle
+      addKeyListener()
     }
     return () => {
+      // Always remove the key listener on cleanup to avoid leaks
+      removeKeyListener()
       if (container) {
         container.removeEventListener("focus", addKeyListener)
         container.removeEventListener("blur", removeKeyListener)


### PR DESCRIPTION
## Summary
- ensure dimension overlay listens for keydown immediately
- clean up key listener on unmount

## Testing
- `bun test`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_68b91017a8c0832ea918d6e0a945a2ca