### PR TITLE
Add click-to-inspect object labels for canvas rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # graphics-debug
 
-Module for debugging graphics, turn log output into meaningful markdown and SVG diagrams.
+Module for debugging graphics, turn log output into meaningful SVG and PNG diagrams.
 
-Just pipe in output with graphics JSON objects into `graphics-debug` (or `gd`) to get an html file
-with all your graphics drawn-in.
+graphics-debug is usually used as a library with tscircuit solvers.
+
+## CLI Usage
 
 ```bash
 echo ':graphics { points: [{x: 0, y: 0, label: "hello world" }], title: "test graphic" } }' | graphics-debug

--- a/lib/drawGraphicsToCanvas.ts
+++ b/lib/drawGraphicsToCanvas.ts
@@ -149,6 +149,9 @@ export function drawGraphicsToCanvas(
   target: HTMLCanvasElement | CanvasRenderingContext2D,
   options: TransformOptions = {},
 ): void {
+  const labelsDisabled = options.disableLabels !== false
+  const inlineLabelsHidden = options.hideInlineLabels ?? labelsDisabled
+
   // Get the context
   const ctx =
     target instanceof HTMLCanvasElement ? target.getContext("2d") : target
@@ -340,7 +343,7 @@ export function drawGraphicsToCanvas(
       ctx.fillStyle = color
       ctx.font = `${fontSize}px sans-serif`
 
-      if (!options.disableLabels && arrow.label) {
+      if (!labelsDisabled && arrow.label) {
         const labelX = arrowLabelLayout.x
         const labelY = arrowLabelLayout.y
 
@@ -351,7 +354,7 @@ export function drawGraphicsToCanvas(
         ctx.restore()
       }
 
-      if (!options.hideInlineLabels && arrow.inlineLabel) {
+      if (!inlineLabelsHidden && arrow.inlineLabel) {
         ctx.save()
         ctx.translate(inlineLabelLayout.x, inlineLabelLayout.y)
         ctx.rotate(inlineLabelLayout.angleRadians)
@@ -525,7 +528,7 @@ export function drawGraphicsToCanvas(
       ctx.fill()
 
       // Draw label if present and labels aren't disabled
-      if (point.label && !options.disableLabels) {
+      if (point.label && !labelsDisabled) {
         ctx.fillStyle = point.color || "black"
         ctx.font = "12px sans-serif"
         ctx.fillText(point.label, projected.x + 5, projected.y - 5)

--- a/lib/getCanvasObjectLabelAtPoint.ts
+++ b/lib/getCanvasObjectLabelAtPoint.ts
@@ -1,0 +1,348 @@
+import { getArrowGeometry } from "./arrowHelpers"
+import type {
+  Arrow,
+  Circle,
+  GraphicsObject,
+  InfiniteLine,
+  Line,
+  Point,
+  Polygon,
+  Rect,
+} from "./types"
+import { applyToPoint, type Matrix } from "transformation-matrix"
+
+const DEFAULT_HIT_SLOP = 8
+
+type ScreenPoint = { x: number; y: number }
+
+const getScaleFactor = (matrix: Matrix) => Math.hypot(matrix.a, matrix.b) || 1
+
+const getDistanceBetweenPoints = (a: ScreenPoint, b: ScreenPoint) => {
+  return Math.hypot(a.x - b.x, a.y - b.y)
+}
+
+const getDistanceToSegment = (
+  point: ScreenPoint,
+  start: ScreenPoint,
+  end: ScreenPoint,
+) => {
+  const deltaX = end.x - start.x
+  const deltaY = end.y - start.y
+  const segmentLengthSquared = deltaX * deltaX + deltaY * deltaY
+
+  if (segmentLengthSquared === 0) {
+    return getDistanceBetweenPoints(point, start)
+  }
+
+  const projection =
+    ((point.x - start.x) * deltaX + (point.y - start.y) * deltaY) /
+    segmentLengthSquared
+  const clampedProjection = Math.max(0, Math.min(1, projection))
+
+  return getDistanceBetweenPoints(point, {
+    x: start.x + deltaX * clampedProjection,
+    y: start.y + deltaY * clampedProjection,
+  })
+}
+
+const getDistanceToInfiniteLine = (
+  point: ScreenPoint,
+  start: ScreenPoint,
+  end: ScreenPoint,
+) => {
+  const deltaX = end.x - start.x
+  const deltaY = end.y - start.y
+  const lineLength = Math.hypot(deltaX, deltaY)
+
+  if (lineLength === 0) {
+    return getDistanceBetweenPoints(point, start)
+  }
+
+  return (
+    Math.abs(
+      deltaY * point.x - deltaX * point.y + end.x * start.y - end.y * start.x,
+    ) / lineLength
+  )
+}
+
+const isPointInPolygon = (point: ScreenPoint, polygon: ScreenPoint[]) => {
+  let isInside = false
+
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const current = polygon[i]
+    const previous = polygon[j]
+    const crossesEdge =
+      current.y > point.y !== previous.y > point.y &&
+      point.x <
+        ((previous.x - current.x) * (point.y - current.y)) /
+          (previous.y - current.y) +
+          current.x
+
+    if (crossesEdge) {
+      isInside = !isInside
+    }
+  }
+
+  return isInside
+}
+
+const isPointNearPolyline = (
+  point: ScreenPoint,
+  polyline: ScreenPoint[],
+  threshold: number,
+  closed = false,
+) => {
+  if (polyline.length === 0) return false
+
+  const segmentCount = closed ? polyline.length : polyline.length - 1
+
+  for (let index = 0; index < segmentCount; index += 1) {
+    const start = polyline[index]
+    const end = polyline[(index + 1) % polyline.length]
+    if (getDistanceToSegment(point, start, end) <= threshold) {
+      return true
+    }
+  }
+
+  return false
+}
+
+const getStrokeHitWidth = (
+  strokeWidth: number | undefined,
+  matrix: Matrix,
+  hitSlop: number,
+) => {
+  return Math.max(
+    hitSlop,
+    ((strokeWidth ?? 2) * getScaleFactor(matrix)) / 2 + 4,
+  )
+}
+
+const projectPoint = (matrix: Matrix, point: Point): ScreenPoint => {
+  return applyToPoint(matrix, point)
+}
+
+const isPointHit = (
+  screenPoint: ScreenPoint,
+  point: Point,
+  matrix: Matrix,
+  hitSlop: number,
+) => {
+  return (
+    getDistanceBetweenPoints(screenPoint, projectPoint(matrix, point)) <=
+    hitSlop
+  )
+}
+
+const isLineHit = (
+  screenPoint: ScreenPoint,
+  line: Line,
+  matrix: Matrix,
+  hitSlop: number,
+) => {
+  if (line.points.length === 0) return false
+  if (line.points.length === 1) {
+    return isPointHit(screenPoint, line.points[0], matrix, hitSlop)
+  }
+
+  const screenPoints = line.points.map((point) => projectPoint(matrix, point))
+  return isPointNearPolyline(
+    screenPoint,
+    screenPoints,
+    getStrokeHitWidth(line.strokeWidth, matrix, hitSlop),
+  )
+}
+
+const isInfiniteLineHit = (
+  screenPoint: ScreenPoint,
+  infiniteLine: InfiniteLine,
+  matrix: Matrix,
+  hitSlop: number,
+) => {
+  const { origin, directionVector } = infiniteLine
+
+  if (directionVector.x === 0 && directionVector.y === 0) {
+    return false
+  }
+
+  const start = projectPoint(matrix, origin)
+  const end = projectPoint(matrix, {
+    x: origin.x + directionVector.x,
+    y: origin.y + directionVector.y,
+  })
+
+  return (
+    getDistanceToInfiniteLine(screenPoint, start, end) <=
+    getStrokeHitWidth(infiniteLine.strokeWidth, matrix, hitSlop)
+  )
+}
+
+const isRectHit = (
+  screenPoint: ScreenPoint,
+  rect: Rect,
+  matrix: Matrix,
+  hitSlop: number,
+) => {
+  const halfWidth = rect.width / 2
+  const halfHeight = rect.height / 2
+  const corners = [
+    { x: rect.center.x - halfWidth, y: rect.center.y - halfHeight },
+    { x: rect.center.x + halfWidth, y: rect.center.y - halfHeight },
+    { x: rect.center.x + halfWidth, y: rect.center.y + halfHeight },
+    { x: rect.center.x - halfWidth, y: rect.center.y + halfHeight },
+  ].map((point) => projectPoint(matrix, point))
+
+  return (
+    isPointInPolygon(screenPoint, corners) ||
+    isPointNearPolyline(screenPoint, corners, hitSlop, true)
+  )
+}
+
+const isCircleHit = (
+  screenPoint: ScreenPoint,
+  circle: Circle,
+  matrix: Matrix,
+  hitSlop: number,
+) => {
+  const center = projectPoint(matrix, circle.center)
+  const radius = circle.radius * getScaleFactor(matrix)
+  return getDistanceBetweenPoints(screenPoint, center) <= radius + hitSlop
+}
+
+const isPolygonHit = (
+  screenPoint: ScreenPoint,
+  polygon: Polygon,
+  matrix: Matrix,
+  hitSlop: number,
+) => {
+  if (polygon.points.length === 0) return false
+  if (polygon.points.length === 1) {
+    return isPointHit(screenPoint, polygon.points[0], matrix, hitSlop)
+  }
+
+  const screenPoints = polygon.points.map((point) =>
+    projectPoint(matrix, point),
+  )
+
+  return (
+    isPointInPolygon(screenPoint, screenPoints) ||
+    isPointNearPolyline(screenPoint, screenPoints, hitSlop, true)
+  )
+}
+
+const isArrowHit = (
+  screenPoint: ScreenPoint,
+  arrow: Arrow,
+  matrix: Matrix,
+  hitSlop: number,
+) => {
+  const geometry = getArrowGeometry(arrow)
+  const shaftStart = projectPoint(matrix, geometry.shaftStart)
+  const shaftEnd = projectPoint(matrix, geometry.shaftEnd)
+  const shaftHitWidth = Math.max(
+    hitSlop,
+    (geometry.shaftWidth * getScaleFactor(matrix)) / 2 + 4,
+  )
+
+  if (
+    getDistanceToSegment(screenPoint, shaftStart, shaftEnd) <= shaftHitWidth
+  ) {
+    return true
+  }
+
+  return geometry.heads.some((head) => {
+    const headPoints = [head.tip, head.leftWing, head.rightWing].map((point) =>
+      projectPoint(matrix, point),
+    )
+    return isPointInPolygon(screenPoint, headPoints)
+  })
+}
+
+export function getCanvasObjectLabelAtPoint(
+  graphics: GraphicsObject,
+  matrix: Matrix,
+  screenPoint: ScreenPoint,
+  options: { hitSlop?: number } = {},
+) {
+  const hitSlop = options.hitSlop ?? DEFAULT_HIT_SLOP
+
+  for (let index = (graphics.points?.length ?? 0) - 1; index >= 0; index -= 1) {
+    const point = graphics.points?.[index]
+    if (!point?.label) continue
+    if (isPointHit(screenPoint, point, matrix, hitSlop)) {
+      return point.label
+    }
+  }
+
+  for (
+    let index = (graphics.infiniteLines?.length ?? 0) - 1;
+    index >= 0;
+    index -= 1
+  ) {
+    const infiniteLine = graphics.infiniteLines?.[index]
+    if (!infiniteLine?.label) continue
+    if (isInfiniteLineHit(screenPoint, infiniteLine, matrix, hitSlop)) {
+      return infiniteLine.label
+    }
+  }
+
+  const sortedLines =
+    graphics.lines
+      ?.map((line, originalIndex) => ({ line, originalIndex }))
+      .sort(
+        (a, b) =>
+          (a.line.zIndex ?? 0) - (b.line.zIndex ?? 0) ||
+          a.originalIndex - b.originalIndex,
+      ) ?? []
+
+  for (let index = sortedLines.length - 1; index >= 0; index -= 1) {
+    const line = sortedLines[index]?.line
+    if (!line?.label) continue
+    if (isLineHit(screenPoint, line, matrix, hitSlop)) {
+      return line.label
+    }
+  }
+
+  for (let index = (graphics.arrows?.length ?? 0) - 1; index >= 0; index -= 1) {
+    const arrow = graphics.arrows?.[index]
+    const label = arrow?.label ?? arrow?.inlineLabel
+    if (!arrow || !label) continue
+    if (isArrowHit(screenPoint, arrow, matrix, hitSlop)) {
+      return label
+    }
+  }
+
+  for (
+    let index = (graphics.polygons?.length ?? 0) - 1;
+    index >= 0;
+    index -= 1
+  ) {
+    const polygon = graphics.polygons?.[index]
+    if (!polygon?.label) continue
+    if (isPolygonHit(screenPoint, polygon, matrix, hitSlop)) {
+      return polygon.label
+    }
+  }
+
+  for (
+    let index = (graphics.circles?.length ?? 0) - 1;
+    index >= 0;
+    index -= 1
+  ) {
+    const circle = graphics.circles?.[index]
+    if (!circle?.label) continue
+    if (isCircleHit(screenPoint, circle, matrix, hitSlop)) {
+      return circle.label
+    }
+  }
+
+  for (let index = (graphics.rects?.length ?? 0) - 1; index >= 0; index -= 1) {
+    const rect = graphics.rects?.[index]
+    if (!rect?.label) continue
+    if (isRectHit(screenPoint, rect, matrix, hitSlop)) {
+      return rect.label
+    }
+  }
+
+  return null
+}

--- a/lib/getCanvasObjectLabelAtPoint.ts
+++ b/lib/getCanvasObjectLabelAtPoint.ts
@@ -16,6 +16,8 @@ const DEFAULT_HIT_SLOP = 8
 type ScreenPoint = { x: number; y: number }
 
 const getScaleFactor = (matrix: Matrix) => Math.hypot(matrix.a, matrix.b) || 1
+const getArrowLabel = (arrow: Arrow) =>
+  [arrow.label, arrow.inlineLabel].filter(Boolean).join("\n")
 
 const getDistanceBetweenPoints = (a: ScreenPoint, b: ScreenPoint) => {
   return Math.hypot(a.x - b.x, a.y - b.y)
@@ -305,7 +307,7 @@ export function getCanvasObjectLabelAtPoint(
 
   for (let index = (graphics.arrows?.length ?? 0) - 1; index >= 0; index -= 1) {
     const arrow = graphics.arrows?.[index]
-    const label = arrow?.label ?? arrow?.inlineLabel
+    const label = arrow ? getArrowLabel(arrow) : ""
     if (!arrow || !label) continue
     if (isArrowHit(screenPoint, arrow, matrix, hitSlop)) {
       return label

--- a/site/components/CanvasGraphics/CanvasGraphics.tsx
+++ b/site/components/CanvasGraphics/CanvasGraphics.tsx
@@ -56,7 +56,7 @@ export const CanvasGraphics = ({
   width = 600,
   height = 600,
   withGrid = true,
-  disableLabels = false,
+  disableLabels = true,
   initialTransform,
 }: CanvasGraphicsProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -141,13 +141,14 @@ export const CanvasGraphics = ({
     drawGraphicsToCanvas(graphics, canvasRef.current, {
       transform: currentTransform,
       disableLabels,
+      hideInlineLabels: disableLabels,
     })
 
     // Draw a grid for reference if enabled
     if (withGrid) {
       drawGrid(canvasRef.current, currentTransform)
     }
-  }, [canvasRef, currentTransform, graphics, size, withGrid])
+  }, [canvasRef, currentTransform, disableLabels, graphics, size, withGrid])
 
   // Draw a grid to help with visualization
   const drawGrid = (canvas: HTMLCanvasElement, transform: Matrix) => {

--- a/site/components/InteractiveGraphics/Arrow.tsx
+++ b/site/components/InteractiveGraphics/Arrow.tsx
@@ -6,6 +6,7 @@ import { safeLighten } from "site/utils/safeLighten"
 import { applyToPoint } from "transformation-matrix"
 import type { InteractiveState } from "./InteractiveState"
 import { defaultColors } from "./defaultColors"
+import { Tooltip } from "./Tooltip"
 
 export const Arrow = ({
   arrow,
@@ -62,6 +63,10 @@ export const Arrow = ({
   const baseColor =
     arrow.color || defaultColors[index % defaultColors.length] || "black"
   const displayColor = isHovered ? safeLighten(0.2, baseColor) : baseColor
+  const tooltipText = [arrow.label, arrow.inlineLabel]
+    .filter(Boolean)
+    .join("\n")
+  const tooltipAnchor = arrow.label ? labelLayout : inlineLabelLayout
 
   const handleMouseMove = (e: React.MouseEvent<SVGSVGElement>) => {
     const rect = e.currentTarget.getBoundingClientRect()
@@ -97,71 +102,64 @@ export const Arrow = ({
   }
 
   return (
-    <svg
+    <div
       style={{
         position: "absolute",
         top: 0,
         left: 0,
         width: "100%",
         height: "100%",
+        pointerEvents: "none",
       }}
-      onMouseMove={handleMouseMove}
-      onMouseLeave={() => setIsHovered(false)}
-      onClick={
-        isHovered
-          ? (event) => {
-              event.stopPropagation()
-              onObjectClicked?.({ type: "arrow", index, object: arrow })
-            }
-          : undefined
-      }
     >
-      <line
-        x1={screenPoints.shaftStart.x}
-        y1={screenPoints.shaftStart.y}
-        x2={screenPoints.shaftEnd.x}
-        y2={screenPoints.shaftEnd.y}
-        stroke={displayColor}
-        strokeWidth={strokeWidth}
-        strokeLinecap="round"
-        pointerEvents="stroke"
-      />
-      {screenPoints.heads.map((head, headIndex) => (
-        <polygon
-          key={headIndex}
-          points={`${head.tip.x},${head.tip.y} ${head.leftWing.x},${head.leftWing.y} ${head.rightWing.x},${head.rightWing.y}`}
-          fill={displayColor}
+      <svg
+        style={{
+          width: "100%",
+          height: "100%",
+          pointerEvents: "auto",
+        }}
+        onMouseMove={handleMouseMove}
+        onMouseLeave={() => setIsHovered(false)}
+        onClick={
+          isHovered
+            ? (event) => {
+                event.stopPropagation()
+                onObjectClicked?.({ type: "arrow", index, object: arrow })
+              }
+            : undefined
+        }
+      >
+        <line
+          x1={screenPoints.shaftStart.x}
+          y1={screenPoints.shaftStart.y}
+          x2={screenPoints.shaftEnd.x}
+          y2={screenPoints.shaftEnd.y}
+          stroke={displayColor}
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          pointerEvents="stroke"
         />
-      ))}
-      {arrow.label && (
-        <text
-          x={labelLayout.x}
-          y={labelLayout.y}
-          fill={displayColor}
-          fontSize={fontSize}
-          fontFamily="sans-serif"
-          textAnchor="middle"
-          dominantBaseline="central"
-          pointerEvents="none"
+        {screenPoints.heads.map((head, headIndex) => (
+          <polygon
+            key={headIndex}
+            points={`${head.tip.x},${head.tip.y} ${head.leftWing.x},${head.leftWing.y} ${head.rightWing.x},${head.rightWing.y}`}
+            fill={displayColor}
+          />
+        ))}
+      </svg>
+      {isHovered && tooltipText && (
+        <div
+          style={{
+            position: "absolute",
+            left: tooltipAnchor.x,
+            top: tooltipAnchor.y - 8,
+            transform: "translate(-50%, -100%)",
+            pointerEvents: "none",
+          }}
         >
-          {arrow.label}
-        </text>
+          <Tooltip text={tooltipText} />
+        </div>
       )}
-      {arrow.inlineLabel && (
-        <text
-          x={inlineLabelLayout.x}
-          y={inlineLabelLayout.y}
-          fill={displayColor}
-          fontSize={fontSize}
-          fontFamily="sans-serif"
-          textAnchor="middle"
-          dominantBaseline="central"
-          transform={`rotate(${inlineLabelLayout.angleDegrees} ${inlineLabelLayout.x} ${inlineLabelLayout.y})`}
-          pointerEvents="none"
-        >
-          {arrow.inlineLabel}
-        </text>
-      )}
-    </svg>
+    </div>
   )
 }

--- a/site/components/InteractiveGraphics/InfiniteLine.tsx
+++ b/site/components/InteractiveGraphics/InfiniteLine.tsx
@@ -3,9 +3,12 @@ import {
   getViewportBoundsFromMatrix,
 } from "lib/infiniteLineHelpers"
 import type * as Types from "lib/types"
+import { useState } from "react"
+import { safeLighten } from "site/utils/safeLighten"
 import { applyToPoint } from "transformation-matrix"
 import type { InteractiveState } from "./InteractiveState"
 import { defaultColors } from "./defaultColors"
+import { Tooltip } from "./Tooltip"
 
 export const InfiniteLine = ({
   infiniteLine,
@@ -19,6 +22,7 @@ export const InfiniteLine = ({
   size: { width: number; height: number }
 }) => {
   const { realToScreen, onObjectClicked } = interactiveState
+  const [isHovered, setIsHovered] = useState(false)
 
   const viewportBounds = getViewportBoundsFromMatrix(
     realToScreen,
@@ -39,9 +43,11 @@ export const InfiniteLine = ({
   const strokeWidth =
     (infiniteLine.strokeWidth ?? 1 / Math.abs(realToScreen.a)) *
     Math.abs(realToScreen.a)
+  const tooltipX = (screenStart.x + screenEnd.x) / 2
+  const tooltipY = (screenStart.y + screenEnd.y) / 2
 
   return (
-    <svg
+    <div
       style={{
         position: "absolute",
         top: 0,
@@ -51,40 +57,63 @@ export const InfiniteLine = ({
         pointerEvents: "none",
       }}
     >
-      <line
-        x1={screenStart.x}
-        y1={screenStart.y}
-        x2={screenEnd.x}
-        y2={screenEnd.y}
-        stroke="transparent"
-        strokeWidth={strokeWidth + 10}
-        pointerEvents="stroke"
-        onClick={() =>
-          onObjectClicked?.({
-            type: "infinite-line",
-            index,
-            object: infiniteLine,
-          })
-        }
-      />
-      <line
-        x1={screenStart.x}
-        y1={screenStart.y}
-        x2={screenEnd.x}
-        y2={screenEnd.y}
-        stroke={baseColor}
-        strokeWidth={strokeWidth}
-        strokeDasharray={
-          !infiniteLine.strokeDash
-            ? undefined
-            : typeof infiniteLine.strokeDash === "string"
-              ? infiniteLine.strokeDash
-              : infiniteLine.strokeDash
-                  .map((dash) => dash * Math.abs(realToScreen.a))
-                  .join(",")
-        }
-        pointerEvents="none"
-      />
-    </svg>
+      <svg
+        style={{
+          width: size.width,
+          height: size.height,
+          pointerEvents: "none",
+        }}
+      >
+        <line
+          x1={screenStart.x}
+          y1={screenStart.y}
+          x2={screenEnd.x}
+          y2={screenEnd.y}
+          stroke="transparent"
+          strokeWidth={strokeWidth + 10}
+          pointerEvents="stroke"
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+          onClick={() =>
+            onObjectClicked?.({
+              type: "infinite-line",
+              index,
+              object: infiniteLine,
+            })
+          }
+        />
+        <line
+          x1={screenStart.x}
+          y1={screenStart.y}
+          x2={screenEnd.x}
+          y2={screenEnd.y}
+          stroke={isHovered ? safeLighten(0.2, baseColor) : baseColor}
+          strokeWidth={strokeWidth}
+          strokeDasharray={
+            !infiniteLine.strokeDash
+              ? undefined
+              : typeof infiniteLine.strokeDash === "string"
+                ? infiniteLine.strokeDash
+                : infiniteLine.strokeDash
+                    .map((dash) => dash * Math.abs(realToScreen.a))
+                    .join(",")
+          }
+          pointerEvents="none"
+        />
+      </svg>
+      {isHovered && infiniteLine.label && (
+        <div
+          style={{
+            position: "absolute",
+            left: tooltipX,
+            top: tooltipY - 8,
+            transform: "translate(-50%, -100%)",
+            pointerEvents: "none",
+          }}
+        >
+          <Tooltip text={infiniteLine.label} />
+        </div>
+      )}
+    </div>
   )
 }

--- a/site/components/InteractiveGraphics/InteractiveGraphics.tsx
+++ b/site/components/InteractiveGraphics/InteractiveGraphics.tsx
@@ -14,6 +14,7 @@ import {
 import useMouseMatrixTransform from "use-mouse-matrix-transform"
 import { GraphicsObject } from "../../../lib"
 import { DimensionOverlay } from "../DimensionOverlay"
+import { ObjectLabelDialog } from "../ObjectLabelDialog"
 import { Arrow } from "./Arrow"
 import { Circle } from "./Circle"
 import { ContextMenu } from "./ContextMenu"
@@ -72,6 +73,10 @@ export const InteractiveGraphics = ({
     clientX: number
     clientY: number
   } | null>(null)
+  const [enableObjectInteraction, setEnableObjectInteraction] = useState(false)
+  const [selectedObjectLabel, setSelectedObjectLabel] = useState<string | null>(
+    null,
+  )
   const [markers, setMarkers] = useState<MarkerPoint[]>([])
   const [mousePosition, setMousePosition] = useState<{
     x: number
@@ -297,14 +302,55 @@ export const InteractiveGraphics = ({
     }
   }, [getSavedData, saveToLocalStorage])
 
+  const getObjectInteractionLabel = useCallback(
+    (event: GraphicsObjectClickEvent) => {
+      switch (event.type) {
+        case "arrow":
+          return [event.object.label, event.object.inlineLabel]
+            .filter(Boolean)
+            .join("\n")
+        case "text":
+          return event.object.text ?? ""
+        default:
+          return event.object.label ?? ""
+      }
+    },
+    [],
+  )
+
+  const handleObjectClicked = useCallback(
+    (event: GraphicsObjectClickEvent) => {
+      onObjectClicked?.(event)
+      if (!enableObjectInteraction) return
+      const label = getObjectInteractionLabel(event)
+      setSelectedObjectLabel(label || null)
+    },
+    [enableObjectInteraction, getObjectInteractionLabel, onObjectClicked],
+  )
+
+  useEffect(() => {
+    if (!selectedObjectLabel) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setSelectedObjectLabel(null)
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown)
+    }
+  }, [selectedObjectLabel])
+
   const interactiveState: InteractiveState = {
     activeLayers: activeLayers,
     activeStep: showLastStep ? maxStep : activeStep,
     realToScreen: realToScreen,
-    onObjectClicked: onObjectClicked,
+    onObjectClicked: handleObjectClicked,
   }
 
-  const showToolbar = availableLayers.length > 1 || maxStep > 0
+  const showToolbar = true
 
   // Use custom hooks for visibility checks and filtering
   const isPointOnScreen = useIsPointOnScreen(realToScreen, size)
@@ -429,7 +475,15 @@ export const InteractiveGraphics = ({
   return (
     <div>
       {showToolbar && (
-        <div style={{ margin: 8 }}>
+        <div
+          style={{
+            margin: 8,
+            display: "flex",
+            alignItems: "center",
+            gap: 12,
+            flexWrap: "wrap",
+          }}
+        >
           {availableLayers.length > 1 && (
             <select
               value={activeLayers ? activeLayers[0] : ""}
@@ -497,6 +551,22 @@ export const InteractiveGraphics = ({
               )}
             </div>
           )}
+
+          <label>
+            <input
+              type="checkbox"
+              style={{ marginRight: 4 }}
+              checked={enableObjectInteraction}
+              onChange={(event) => {
+                const isEnabled = event.target.checked
+                setEnableObjectInteraction(isEnabled)
+                if (!isEnabled) {
+                  setSelectedObjectLabel(null)
+                }
+              }}
+            />
+            Enable Object Interation
+          </label>
         </div>
       )}
 
@@ -611,6 +681,14 @@ export const InteractiveGraphics = ({
             onAddMark={handleAddMark}
             onClearMarks={handleClearMarks}
             onClose={() => setContextMenu(null)}
+          />
+        )}
+        {selectedObjectLabel && (
+          <ObjectLabelDialog
+            label={selectedObjectLabel}
+            onClose={() => {
+              setSelectedObjectLabel(null)
+            }}
           />
         )}
       </div>

--- a/site/components/InteractiveGraphics/Line.tsx
+++ b/site/components/InteractiveGraphics/Line.tsx
@@ -64,62 +64,73 @@ export const Line = ({
   const baseColor = strokeColor ?? defaultColors[index % defaultColors.length]
 
   return (
-    <svg
+    <div
       style={{
         position: "absolute",
         top: 0,
         left: 0,
         width: size.width,
         height: size.height,
-        overflow: "visible",
         pointerEvents: "none",
       }}
     >
-      <polyline
-        points={screenPoints.map((p) => `${p.x},${p.y}`).join(" ")}
-        stroke="transparent"
-        fill="none"
-        strokeWidth={hitStrokeWidth}
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        pointerEvents="stroke"
-        onClick={
-          isHovered
-            ? () =>
-                onObjectClicked?.({
-                  type: "line",
-                  index,
-                  object: line,
-                })
-            : undefined
-        }
-      />
-      <polyline
-        points={screenPoints.map((p) => `${p.x},${p.y}`).join(" ")}
-        stroke={isHovered ? safeLighten(0.2, baseColor) : baseColor}
-        fill="none"
-        strokeWidth={screenStrokeWidth}
-        strokeDasharray={
-          !strokeDash
-            ? undefined
-            : typeof strokeDash === "string"
-              ? strokeDash
-              : `${strokeDash[0] * Math.abs(realToScreen.a)}, ${strokeDash[1] * Math.abs(realToScreen.a)}`
-        }
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        pointerEvents="none"
-      />
-      {isHovered && line.label && (
-        <foreignObject
-          x={mousePosition?.x ?? 0}
-          y={(mousePosition?.y ?? 0) - 40}
-          width={300}
-          height={40}
+      <svg
+        style={{
+          width: size.width,
+          height: size.height,
+          overflow: "visible",
+          pointerEvents: "none",
+        }}
+      >
+        <polyline
+          points={screenPoints.map((p) => `${p.x},${p.y}`).join(" ")}
+          stroke="transparent"
+          fill="none"
+          strokeWidth={hitStrokeWidth}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          pointerEvents="stroke"
+          onClick={
+            isHovered
+              ? () =>
+                  onObjectClicked?.({
+                    type: "line",
+                    index,
+                    object: line,
+                  })
+              : undefined
+          }
+        />
+        <polyline
+          points={screenPoints.map((p) => `${p.x},${p.y}`).join(" ")}
+          stroke={isHovered ? safeLighten(0.2, baseColor) : baseColor}
+          fill="none"
+          strokeWidth={screenStrokeWidth}
+          strokeDasharray={
+            !strokeDash
+              ? undefined
+              : typeof strokeDash === "string"
+                ? strokeDash
+                : `${strokeDash[0] * Math.abs(realToScreen.a)}, ${strokeDash[1] * Math.abs(realToScreen.a)}`
+          }
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          pointerEvents="none"
+        />
+      </svg>
+      {isHovered && line.label && mousePosition && (
+        <div
+          style={{
+            position: "absolute",
+            left: mousePosition.x,
+            top: mousePosition.y - 8,
+            transform: "translate(-50%, -100%)",
+            pointerEvents: "none",
+          }}
         >
           <Tooltip text={line.label} />
-        </foreignObject>
+        </div>
       )}
-    </svg>
+    </div>
   )
 }

--- a/site/components/InteractiveGraphics/Tooltip.tsx
+++ b/site/components/InteractiveGraphics/Tooltip.tsx
@@ -8,11 +8,10 @@ export const Tooltip = ({ text }: { text: string }) => {
         borderRadius: "4px",
         padding: "4px 8px",
         fontSize: "12px",
-        minWidth: "150px",
+        minWidth: "120px",
         maxWidth: "300px",
-        overflow: "hidden",
-        textOverflow: "ellipsis",
         whiteSpace: "pre-wrap",
+        overflowWrap: "anywhere",
         zIndex: 100,
       }}
     >

--- a/site/components/InteractiveGraphicsCanvas.tsx
+++ b/site/components/InteractiveGraphicsCanvas.tsx
@@ -1,8 +1,9 @@
-import { useRef, useEffect, useState } from "react"
+import { useRef, useEffect, useState, type MouseEvent } from "react"
 import { drawGraphicsToCanvas, type GraphicsObject } from "../../lib"
 import useMouseMatrixTransform from "use-mouse-matrix-transform"
-import { compose, scale, translate } from "transformation-matrix"
+import { compose, scale, translate, type Matrix } from "transformation-matrix"
 import useResizeObserver from "@react-hook/resize-observer"
+import { getCanvasObjectLabelAtPoint } from "../../lib/getCanvasObjectLabelAtPoint"
 import { getMaxStep } from "site/utils/getMaxStep"
 import { getGraphicsFilteredByStep } from "site/utils/getGraphicsFilteredByStep"
 import { getGraphicsBoundsWithPadding } from "site/utils/getGraphicsBoundsWithPadding"
@@ -17,7 +18,7 @@ interface InteractiveGraphicsCanvasProps {
 
 export function InteractiveGraphicsCanvas({
   graphics,
-  showLabelsByDefault = true,
+  showLabelsByDefault = false,
   showGrid = true,
   height = 500,
   width = "100%",
@@ -28,6 +29,10 @@ export function InteractiveGraphicsCanvas({
   const [activeStep, setActiveStep] = useState<number | null>(null)
   const [showLabels, setShowLabels] = useState(showLabelsByDefault)
   const [showLastStep, setShowLastStep] = useState(true)
+  const [enableObjectInteraction, setEnableObjectInteraction] = useState(false)
+  const [selectedObjectLabel, setSelectedObjectLabel] = useState<string | null>(
+    null,
+  )
 
   // Calculate the maximum step value from all graphics objects
   const maxStep = getMaxStep(graphics)
@@ -87,6 +92,7 @@ export function InteractiveGraphicsCanvas({
     drawGraphicsToCanvas(filteredGraphics, canvasRef.current, {
       transform: transform,
       disableLabels: !showLabels,
+      hideInlineLabels: !showLabels,
     })
 
     // Draw a grid for reference if requested
@@ -96,7 +102,7 @@ export function InteractiveGraphicsCanvas({
   }
 
   // Draw a grid to help with visualization
-  const drawGrid = (canvas: HTMLCanvasElement, transform: any) => {
+  const drawGrid = (canvas: HTMLCanvasElement, transform: Matrix) => {
     const ctx = canvas.getContext("2d")
     if (!ctx) return
 
@@ -162,17 +168,55 @@ export function InteractiveGraphicsCanvas({
   }
 
   // Helper to transform a point through the matrix
-  const transformPoint = (point: { x: number; y: number }, matrix: any) => {
+  const transformPoint = (point: { x: number; y: number }, matrix: Matrix) => {
     return {
       x: matrix.a * point.x + matrix.c * point.y + matrix.e,
       y: matrix.b * point.x + matrix.d * point.y + matrix.f,
     }
   }
 
+  const handleCanvasClick = (event: MouseEvent<HTMLCanvasElement>) => {
+    if (!enableObjectInteraction || !canvasRef.current) return
+
+    const canvas = canvasRef.current
+    const bounds = canvas.getBoundingClientRect()
+    const scaleX = bounds.width === 0 ? 1 : canvas.width / bounds.width
+    const scaleY = bounds.height === 0 ? 1 : canvas.height / bounds.height
+
+    const label = getCanvasObjectLabelAtPoint(
+      filteredGraphics,
+      transform,
+      {
+        x: (event.clientX - bounds.left) * scaleX,
+        y: (event.clientY - bounds.top) * scaleY,
+      },
+      {
+        hitSlop: 8,
+      },
+    )
+
+    setSelectedObjectLabel(label)
+  }
+
   // Apply the drawing when transform changes
   useEffect(() => {
     drawCanvas()
   }, [transform, size, filteredGraphics, showGrid, showLabels])
+
+  useEffect(() => {
+    if (!selectedObjectLabel) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setSelectedObjectLabel(null)
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown)
+    }
+  }, [selectedObjectLabel])
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
@@ -230,6 +274,22 @@ export function InteractiveGraphicsCanvas({
             />
             Show labels
           </label>
+
+          <label>
+            <input
+              type="checkbox"
+              style={{ marginRight: 4 }}
+              checked={enableObjectInteraction}
+              onChange={(event) => {
+                const isEnabled = event.target.checked
+                setEnableObjectInteraction(isEnabled)
+                if (!isEnabled) {
+                  setSelectedObjectLabel(null)
+                }
+              }}
+            />
+            Enable Object Interation
+          </label>
         </div>
       </div>
 
@@ -252,6 +312,7 @@ export function InteractiveGraphicsCanvas({
       >
         <canvas
           ref={canvasRef}
+          onClick={handleCanvasClick}
           style={{
             position: "absolute",
             top: 0,
@@ -260,6 +321,62 @@ export function InteractiveGraphicsCanvas({
             height,
           }}
         />
+
+        {selectedObjectLabel && (
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Object label"
+            onClick={() => {
+              setSelectedObjectLabel(null)
+            }}
+            style={{
+              position: "absolute",
+              inset: 0,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              padding: 16,
+              background: "rgba(0, 0, 0, 0.28)",
+            }}
+          >
+            <div
+              onClick={(event) => {
+                event.stopPropagation()
+              }}
+              style={{
+                width: "min(420px, 100%)",
+                background: "#fff",
+                borderRadius: 10,
+                boxShadow: "0 12px 32px rgba(0, 0, 0, 0.2)",
+                padding: 16,
+              }}
+            >
+              <div style={{ fontWeight: 600, marginBottom: 8 }}>
+                Object label
+              </div>
+              <div
+                style={{
+                  whiteSpace: "pre-wrap",
+                  wordBreak: "break-word",
+                  marginBottom: 16,
+                }}
+              >
+                {selectedObjectLabel}
+              </div>
+              <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSelectedObjectLabel(null)
+                  }}
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/site/components/InteractiveGraphicsCanvas.tsx
+++ b/site/components/InteractiveGraphicsCanvas.tsx
@@ -4,6 +4,8 @@ import useMouseMatrixTransform from "use-mouse-matrix-transform"
 import { compose, scale, translate, type Matrix } from "transformation-matrix"
 import useResizeObserver from "@react-hook/resize-observer"
 import { getCanvasObjectLabelAtPoint } from "../../lib/getCanvasObjectLabelAtPoint"
+import { ObjectLabelDialog } from "./ObjectLabelDialog"
+import { Tooltip } from "./InteractiveGraphics/Tooltip"
 import { getMaxStep } from "site/utils/getMaxStep"
 import { getGraphicsFilteredByStep } from "site/utils/getGraphicsFilteredByStep"
 import { getGraphicsBoundsWithPadding } from "site/utils/getGraphicsBoundsWithPadding"
@@ -18,7 +20,6 @@ interface InteractiveGraphicsCanvasProps {
 
 export function InteractiveGraphicsCanvas({
   graphics,
-  showLabelsByDefault = false,
   showGrid = true,
   height = 500,
   width = "100%",
@@ -27,9 +28,15 @@ export function InteractiveGraphicsCanvas({
   const containerRef = useRef<HTMLDivElement | null>(null)
   const [size, setSize] = useState({ width: 600, height: 600 })
   const [activeStep, setActiveStep] = useState<number | null>(null)
-  const [showLabels, setShowLabels] = useState(showLabelsByDefault)
   const [showLastStep, setShowLastStep] = useState(true)
   const [enableObjectInteraction, setEnableObjectInteraction] = useState(false)
+  const [hoveredObjectLabel, setHoveredObjectLabel] = useState<string | null>(
+    null,
+  )
+  const [hoveredObjectPosition, setHoveredObjectPosition] = useState<{
+    x: number
+    y: number
+  } | null>(null)
   const [selectedObjectLabel, setSelectedObjectLabel] = useState<string | null>(
     null,
   )
@@ -91,8 +98,8 @@ export function InteractiveGraphicsCanvas({
     // Draw the graphics with the current transform
     drawGraphicsToCanvas(filteredGraphics, canvasRef.current, {
       transform: transform,
-      disableLabels: !showLabels,
-      hideInlineLabels: !showLabels,
+      disableLabels: true,
+      hideInlineLabels: true,
     })
 
     // Draw a grid for reference if requested
@@ -175,33 +182,60 @@ export function InteractiveGraphicsCanvas({
     }
   }
 
-  const handleCanvasClick = (event: MouseEvent<HTMLCanvasElement>) => {
-    if (!enableObjectInteraction || !canvasRef.current) return
+  const getCanvasLabelFromEvent = (event: MouseEvent<HTMLCanvasElement>) => {
+    if (!canvasRef.current) {
+      return {
+        label: null,
+        overlayPoint: null,
+      }
+    }
 
     const canvas = canvasRef.current
     const bounds = canvas.getBoundingClientRect()
     const scaleX = bounds.width === 0 ? 1 : canvas.width / bounds.width
     const scaleY = bounds.height === 0 ? 1 : canvas.height / bounds.height
 
+    const overlayPoint = {
+      x: event.clientX - bounds.left,
+      y: event.clientY - bounds.top,
+    }
+
     const label = getCanvasObjectLabelAtPoint(
       filteredGraphics,
       transform,
       {
-        x: (event.clientX - bounds.left) * scaleX,
-        y: (event.clientY - bounds.top) * scaleY,
+        x: overlayPoint.x * scaleX,
+        y: overlayPoint.y * scaleY,
       },
       {
         hitSlop: 8,
       },
     )
 
+    return { label, overlayPoint }
+  }
+
+  const handleCanvasMouseMove = (event: MouseEvent<HTMLCanvasElement>) => {
+    const { label, overlayPoint } = getCanvasLabelFromEvent(event)
+    setHoveredObjectLabel(label)
+    setHoveredObjectPosition(label ? overlayPoint : null)
+  }
+
+  const handleCanvasMouseLeave = () => {
+    setHoveredObjectLabel(null)
+    setHoveredObjectPosition(null)
+  }
+
+  const handleCanvasClick = (event: MouseEvent<HTMLCanvasElement>) => {
+    if (!enableObjectInteraction) return
+    const { label } = getCanvasLabelFromEvent(event)
     setSelectedObjectLabel(label)
   }
 
   // Apply the drawing when transform changes
   useEffect(() => {
     drawCanvas()
-  }, [transform, size, filteredGraphics, showGrid, showLabels])
+  }, [transform, size, filteredGraphics, showGrid])
 
   useEffect(() => {
     if (!selectedObjectLabel) return
@@ -267,18 +301,6 @@ export function InteractiveGraphicsCanvas({
             <input
               type="checkbox"
               style={{ marginRight: 4 }}
-              checked={showLabels}
-              onChange={(e) => {
-                setShowLabels(e.target.checked)
-              }}
-            />
-            Show labels
-          </label>
-
-          <label>
-            <input
-              type="checkbox"
-              style={{ marginRight: 4 }}
               checked={enableObjectInteraction}
               onChange={(event) => {
                 const isEnabled = event.target.checked
@@ -312,6 +334,8 @@ export function InteractiveGraphicsCanvas({
       >
         <canvas
           ref={canvasRef}
+          onMouseMove={handleCanvasMouseMove}
+          onMouseLeave={handleCanvasMouseLeave}
           onClick={handleCanvasClick}
           style={{
             position: "absolute",
@@ -322,60 +346,27 @@ export function InteractiveGraphicsCanvas({
           }}
         />
 
-        {selectedObjectLabel && (
+        {hoveredObjectLabel && hoveredObjectPosition && (
           <div
-            role="dialog"
-            aria-modal="true"
-            aria-label="Object label"
-            onClick={() => {
-              setSelectedObjectLabel(null)
-            }}
             style={{
               position: "absolute",
-              inset: 0,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              padding: 16,
-              background: "rgba(0, 0, 0, 0.28)",
+              left: hoveredObjectPosition.x,
+              top: hoveredObjectPosition.y - 12,
+              transform: "translate(-50%, -100%)",
+              pointerEvents: "none",
             }}
           >
-            <div
-              onClick={(event) => {
-                event.stopPropagation()
-              }}
-              style={{
-                width: "min(420px, 100%)",
-                background: "#fff",
-                borderRadius: 10,
-                boxShadow: "0 12px 32px rgba(0, 0, 0, 0.2)",
-                padding: 16,
-              }}
-            >
-              <div style={{ fontWeight: 600, marginBottom: 8 }}>
-                Object label
-              </div>
-              <div
-                style={{
-                  whiteSpace: "pre-wrap",
-                  wordBreak: "break-word",
-                  marginBottom: 16,
-                }}
-              >
-                {selectedObjectLabel}
-              </div>
-              <div style={{ display: "flex", justifyContent: "flex-end" }}>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setSelectedObjectLabel(null)
-                  }}
-                >
-                  Close
-                </button>
-              </div>
-            </div>
+            <Tooltip text={hoveredObjectLabel} />
           </div>
+        )}
+
+        {selectedObjectLabel && (
+          <ObjectLabelDialog
+            label={selectedObjectLabel}
+            onClose={() => {
+              setSelectedObjectLabel(null)
+            }}
+          />
         )}
       </div>
     </div>

--- a/site/components/ObjectLabelDialog.tsx
+++ b/site/components/ObjectLabelDialog.tsx
@@ -1,0 +1,54 @@
+export const ObjectLabelDialog = ({
+  label,
+  onClose,
+}: {
+  label: string
+  onClose: () => void
+}) => {
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Object label"
+      onClick={onClose}
+      style={{
+        position: "absolute",
+        inset: 0,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 16,
+        background: "rgba(0, 0, 0, 0.28)",
+      }}
+    >
+      <div
+        onClick={(event) => {
+          event.stopPropagation()
+        }}
+        style={{
+          width: "min(420px, 100%)",
+          background: "#fff",
+          borderRadius: 10,
+          boxShadow: "0 12px 32px rgba(0, 0, 0, 0.2)",
+          padding: 16,
+        }}
+      >
+        <div style={{ fontWeight: 600, marginBottom: 8 }}>Object label</div>
+        <div
+          style={{
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-word",
+            marginBottom: 16,
+          }}
+        >
+          {label}
+        </div>
+        <div style={{ display: "flex", justifyContent: "flex-end" }}>
+          <button type="button" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/tests/getCanvasObjectLabelAtPoint.test.ts
+++ b/tests/getCanvasObjectLabelAtPoint.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test"
+import type { GraphicsObject } from "../lib"
+import { getCanvasObjectLabelAtPoint } from "../lib/getCanvasObjectLabelAtPoint"
+import type { Matrix } from "transformation-matrix"
+
+const identityMatrix = {
+  a: 1,
+  b: 0,
+  c: 0,
+  d: 1,
+  e: 0,
+  f: 0,
+} as Matrix
+
+describe("getCanvasObjectLabelAtPoint", () => {
+  test("prefers topmost points over shapes drawn earlier", () => {
+    const graphics: GraphicsObject = {
+      rects: [
+        {
+          center: { x: 0, y: 0 },
+          width: 40,
+          height: 40,
+          label: "Bounding box",
+        },
+      ],
+      points: [{ x: 0, y: 0, label: "Origin" }],
+    }
+
+    expect(
+      getCanvasObjectLabelAtPoint(graphics, identityMatrix, { x: 0, y: 0 }),
+    ).toBe("Origin")
+  })
+
+  test("returns the highest z-index line label when lines overlap", () => {
+    const graphics: GraphicsObject = {
+      lines: [
+        {
+          points: [
+            { x: 0, y: 0 },
+            { x: 20, y: 0 },
+          ],
+          label: "Bottom line",
+          zIndex: 0,
+        },
+        {
+          points: [
+            { x: 0, y: 0 },
+            { x: 20, y: 0 },
+          ],
+          label: "Top line",
+          zIndex: 1,
+        },
+      ],
+    }
+
+    expect(
+      getCanvasObjectLabelAtPoint(graphics, identityMatrix, { x: 10, y: 1 }),
+    ).toBe("Top line")
+  })
+
+  test("detects rect, circle, and polygon hits from clicks inside the shape", () => {
+    const graphics: GraphicsObject = {
+      rects: [
+        {
+          center: { x: 10, y: 10 },
+          width: 12,
+          height: 12,
+          label: "Rect label",
+        },
+      ],
+      circles: [{ center: { x: 40, y: 40 }, radius: 8, label: "Circle label" }],
+      polygons: [
+        {
+          points: [
+            { x: 70, y: 10 },
+            { x: 82, y: 10 },
+            { x: 76, y: 24 },
+          ],
+          label: "Polygon label",
+        },
+      ],
+    }
+
+    expect(
+      getCanvasObjectLabelAtPoint(graphics, identityMatrix, { x: 10, y: 10 }),
+    ).toBe("Rect label")
+    expect(
+      getCanvasObjectLabelAtPoint(graphics, identityMatrix, { x: 40, y: 40 }),
+    ).toBe("Circle label")
+    expect(
+      getCanvasObjectLabelAtPoint(graphics, identityMatrix, { x: 76, y: 14 }),
+    ).toBe("Polygon label")
+  })
+
+  test("detects arrow hits and falls back to inline labels", () => {
+    const graphics: GraphicsObject = {
+      arrows: [
+        {
+          start: { x: 0, y: 0 },
+          end: { x: 24, y: 0 },
+          inlineLabel: "v_out",
+        },
+      ],
+    }
+
+    expect(
+      getCanvasObjectLabelAtPoint(graphics, identityMatrix, { x: 12, y: 1 }),
+    ).toBe("v_out")
+  })
+
+  test("detects infinite line labels", () => {
+    const graphics: GraphicsObject = {
+      infiniteLines: [
+        {
+          origin: { x: 0, y: 0 },
+          directionVector: { x: 1, y: 0 },
+          label: "X axis",
+        },
+      ],
+    }
+
+    expect(
+      getCanvasObjectLabelAtPoint(graphics, identityMatrix, { x: 50, y: 3 }),
+    ).toBe("X axis")
+  })
+
+  test("returns null when the click misses or the object is unlabeled", () => {
+    const graphics: GraphicsObject = {
+      points: [{ x: 0, y: 0 }],
+      rects: [
+        {
+          center: { x: 20, y: 20 },
+          width: 10,
+          height: 10,
+          label: "Rect label",
+        },
+      ],
+    }
+
+    expect(
+      getCanvasObjectLabelAtPoint(graphics, identityMatrix, { x: 100, y: 100 }),
+    ).toBeNull()
+  })
+})

--- a/tests/getCanvasObjectLabelAtPoint.test.ts
+++ b/tests/getCanvasObjectLabelAtPoint.test.ts
@@ -92,12 +92,13 @@ describe("getCanvasObjectLabelAtPoint", () => {
     ).toBe("Polygon label")
   })
 
-  test("detects arrow hits and falls back to inline labels", () => {
+  test("detects arrow hits and combines multiline arrow labels", () => {
     const graphics: GraphicsObject = {
       arrows: [
         {
           start: { x: 0, y: 0 },
           end: { x: 24, y: 0 },
+          label: "I_out",
           inlineLabel: "v_out",
         },
       ],
@@ -105,7 +106,7 @@ describe("getCanvasObjectLabelAtPoint", () => {
 
     expect(
       getCanvasObjectLabelAtPoint(graphics, identityMatrix, { x: 12, y: 1 }),
-    ).toBe("v_out")
+    ).toBe("I_out\nv_out")
   })
 
   test("detects infinite line labels", () => {


### PR DESCRIPTION
## Summary
- hide canvas labels by default, including inline arrow labels, unless explicitly enabled
- add an `Enable Object Interation` debug toggle that opens a dialog when a labeled canvas object is clicked
- add shared canvas hit-testing for points, lines, arrows, polygons, circles, rects, and infinite lines
- cover the new hit-testing behavior with targeted tests

## Testing
- `bun test`
- `bun run build`