### PR TITLE
Fix hover labels rendering above shapes

### DIFF
--- a/site/components/InteractiveGraphics/Arrow.tsx
+++ b/site/components/InteractiveGraphics/Arrow.tsx
@@ -1,12 +1,11 @@
 import { getArrowGeometry, getInlineLabelLayout } from "lib/arrowHelpers"
 import type * as Types from "lib/types"
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { distToLineSegment } from "site/utils/distToLineSegment"
 import { safeLighten } from "site/utils/safeLighten"
 import { applyToPoint } from "transformation-matrix"
 import type { InteractiveState } from "./InteractiveState"
 import { defaultColors } from "./defaultColors"
-import { Tooltip } from "./Tooltip"
 
 export const Arrow = ({
   arrow,
@@ -17,7 +16,7 @@ export const Arrow = ({
   index: number
   interactiveState: InteractiveState
 }) => {
-  const { realToScreen, onObjectClicked } = interactiveState
+  const { realToScreen, onObjectClicked, setHoverTooltip } = interactiveState
   const [isHovered, setIsHovered] = useState(false)
 
   const geometry = useMemo(() => getArrowGeometry(arrow), [arrow])
@@ -67,6 +66,26 @@ export const Arrow = ({
     .filter(Boolean)
     .join("\n")
   const tooltipAnchor = arrow.label ? labelLayout : inlineLabelLayout
+
+  useEffect(() => {
+    if (!isHovered || !tooltipText) return
+
+    setHoverTooltip?.({
+      text: tooltipText,
+      x: tooltipAnchor.x,
+      y: tooltipAnchor.y,
+    })
+
+    return () => {
+      setHoverTooltip?.(null)
+    }
+  }, [
+    isHovered,
+    setHoverTooltip,
+    tooltipAnchor.x,
+    tooltipAnchor.y,
+    tooltipText,
+  ])
 
   const handleMouseMove = (e: React.MouseEvent<SVGSVGElement>) => {
     const rect = e.currentTarget.getBoundingClientRect()
@@ -119,7 +138,10 @@ export const Arrow = ({
           pointerEvents: "auto",
         }}
         onMouseMove={handleMouseMove}
-        onMouseLeave={() => setIsHovered(false)}
+        onMouseLeave={() => {
+          setIsHovered(false)
+          setHoverTooltip?.(null)
+        }}
         onClick={
           isHovered
             ? (event) => {
@@ -147,19 +169,6 @@ export const Arrow = ({
           />
         ))}
       </svg>
-      {isHovered && tooltipText && (
-        <div
-          style={{
-            position: "absolute",
-            left: tooltipAnchor.x,
-            top: tooltipAnchor.y - 8,
-            transform: "translate(-50%, -100%)",
-            pointerEvents: "none",
-          }}
-        >
-          <Tooltip text={tooltipText} />
-        </div>
-      )}
     </div>
   )
 }

--- a/site/components/InteractiveGraphics/Circle.tsx
+++ b/site/components/InteractiveGraphics/Circle.tsx
@@ -1,8 +1,7 @@
 import type * as Types from "lib/types"
 import { applyToPoint } from "transformation-matrix"
 import type { InteractiveState } from "./InteractiveState"
-import { useState } from "react"
-import { Tooltip } from "./Tooltip"
+import { useEffect, useState } from "react"
 import { defaultColors } from "./defaultColors"
 import { safeLighten } from "site/utils/safeLighten"
 
@@ -17,8 +16,13 @@ export const Circle = ({
 }) => {
   const defaultColor = defaultColors[index % defaultColors.length]
   let { center, radius, fill, stroke, layer, step, label } = circle
-  const { activeLayers, activeStep, realToScreen, onObjectClicked } =
-    interactiveState
+  const {
+    activeLayers,
+    activeStep,
+    realToScreen,
+    onObjectClicked,
+    setHoverTooltip,
+  } = interactiveState
   const [isHovered, setIsHovered] = useState(false)
   const screenCenter = applyToPoint(realToScreen, center)
   const screenRadius = radius * realToScreen.a
@@ -27,6 +31,28 @@ export const Circle = ({
     backgroundColor = safeLighten(0.2, backgroundColor)
     stroke = stroke ? safeLighten(0.2, stroke) : stroke
   }
+
+  useEffect(() => {
+    if (!isHovered || !label) return
+
+    setHoverTooltip?.({
+      text: label,
+      x: screenCenter.x,
+      y: screenCenter.y - screenRadius,
+    })
+
+    return () => {
+      setHoverTooltip?.(null)
+    }
+  }, [
+    isHovered,
+    label,
+    screenCenter.x,
+    screenCenter.y,
+    screenRadius,
+    setHoverTooltip,
+  ])
+
   return (
     <div
       style={{
@@ -42,7 +68,10 @@ export const Circle = ({
         transition: "border-color 0.2s",
       }}
       onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
+      onMouseLeave={() => {
+        setIsHovered(false)
+        setHoverTooltip?.(null)
+      }}
       onClick={() =>
         onObjectClicked?.({
           type: "circle",
@@ -50,20 +79,6 @@ export const Circle = ({
           object: circle,
         })
       }
-    >
-      {isHovered && label && (
-        <div
-          style={{
-            position: "absolute",
-            bottom: "100%",
-            left: "50%",
-            transform: "translateX(-50%)",
-            marginBottom: 8,
-          }}
-        >
-          <Tooltip text={label} />
-        </div>
-      )}
-    </div>
+    ></div>
   )
 }

--- a/site/components/InteractiveGraphics/InfiniteLine.tsx
+++ b/site/components/InteractiveGraphics/InfiniteLine.tsx
@@ -8,7 +8,6 @@ import { safeLighten } from "site/utils/safeLighten"
 import { applyToPoint } from "transformation-matrix"
 import type { InteractiveState } from "./InteractiveState"
 import { defaultColors } from "./defaultColors"
-import { Tooltip } from "./Tooltip"
 
 export const InfiniteLine = ({
   infiniteLine,
@@ -21,7 +20,7 @@ export const InfiniteLine = ({
   interactiveState: InteractiveState
   size: { width: number; height: number }
 }) => {
-  const { realToScreen, onObjectClicked } = interactiveState
+  const { realToScreen, onObjectClicked, setHoverTooltip } = interactiveState
   const [isHovered, setIsHovered] = useState(false)
 
   const viewportBounds = getViewportBoundsFromMatrix(
@@ -72,8 +71,20 @@ export const InfiniteLine = ({
           stroke="transparent"
           strokeWidth={strokeWidth + 10}
           pointerEvents="stroke"
-          onMouseEnter={() => setIsHovered(true)}
-          onMouseLeave={() => setIsHovered(false)}
+          onMouseEnter={() => {
+            setIsHovered(true)
+            if (infiniteLine.label) {
+              setHoverTooltip?.({
+                text: infiniteLine.label,
+                x: tooltipX,
+                y: tooltipY,
+              })
+            }
+          }}
+          onMouseLeave={() => {
+            setIsHovered(false)
+            setHoverTooltip?.(null)
+          }}
           onClick={() =>
             onObjectClicked?.({
               type: "infinite-line",
@@ -101,19 +112,6 @@ export const InfiniteLine = ({
           pointerEvents="none"
         />
       </svg>
-      {isHovered && infiniteLine.label && (
-        <div
-          style={{
-            position: "absolute",
-            left: tooltipX,
-            top: tooltipY - 8,
-            transform: "translate(-50%, -100%)",
-            pointerEvents: "none",
-          }}
-        >
-          <Tooltip text={infiniteLine.label} />
-        </div>
-      )}
     </div>
   )
 }

--- a/site/components/InteractiveGraphics/InteractiveGraphics.tsx
+++ b/site/components/InteractiveGraphics/InteractiveGraphics.tsx
@@ -26,6 +26,7 @@ import { Point } from "./Point"
 import { Polygon } from "./Polygon"
 import { Rect } from "./Rect"
 import { Text } from "./Text"
+import { Tooltip } from "./Tooltip"
 import {
   useDoesLineIntersectViewport,
   useFilterArrows,
@@ -37,6 +38,7 @@ import {
   useFilterTexts,
   useIsPointOnScreen,
 } from "./hooks"
+import { tooltipLayerZIndex } from "./tooltipLayer"
 
 export type GraphicsObjectClickEvent = {
   type:
@@ -79,6 +81,11 @@ export const InteractiveGraphics = ({
   )
   const [markers, setMarkers] = useState<MarkerPoint[]>([])
   const [mousePosition, setMousePosition] = useState<{
+    x: number
+    y: number
+  } | null>(null)
+  const [hoverTooltip, setHoverTooltip] = useState<{
+    text: string
     x: number
     y: number
   } | null>(null)
@@ -348,6 +355,7 @@ export const InteractiveGraphics = ({
     activeStep: showLastStep ? maxStep : activeStep,
     realToScreen: realToScreen,
     onObjectClicked: handleObjectClicked,
+    setHoverTooltip,
   }
 
   const showToolbar = true
@@ -671,6 +679,20 @@ export const InteractiveGraphics = ({
             transform={realToScreen}
           />
         ))}
+        {hoverTooltip && (
+          <div
+            style={{
+              position: "absolute",
+              left: hoverTooltip.x,
+              top: hoverTooltip.y - 8,
+              transform: "translate(-50%, -100%)",
+              pointerEvents: "none",
+              zIndex: tooltipLayerZIndex,
+            }}
+          >
+            <Tooltip text={hoverTooltip.text} />
+          </div>
+        )}
         {contextMenu && (
           <ContextMenu
             x={contextMenu.x}

--- a/site/components/InteractiveGraphics/InteractiveState.ts
+++ b/site/components/InteractiveGraphics/InteractiveState.ts
@@ -6,4 +6,11 @@ export type InteractiveState = {
   activeStep: number | null
   realToScreen: Matrix
   onObjectClicked?: (event: GraphicsObjectClickEvent) => void
+  setHoverTooltip?: (tooltip: HoverTooltip | null) => void
+}
+
+export type HoverTooltip = {
+  text: string
+  x: number
+  y: number
 }

--- a/site/components/InteractiveGraphics/Line.tsx
+++ b/site/components/InteractiveGraphics/Line.tsx
@@ -1,8 +1,7 @@
 import type * as Types from "lib/types"
 import { applyToPoint } from "transformation-matrix"
 import type { InteractiveState } from "./InteractiveState"
-import { useMemo } from "react"
-import { Tooltip } from "./Tooltip"
+import { useEffect, useMemo } from "react"
 import { distToLineSegment } from "site/utils/distToLineSegment"
 import { defaultColors } from "./defaultColors"
 import { safeLighten } from "site/utils/safeLighten"
@@ -20,8 +19,13 @@ export const Line = ({
   size: { width: number; height: number }
   mousePosition: { x: number; y: number } | null
 }) => {
-  const { activeLayers, activeStep, realToScreen, onObjectClicked } =
-    interactiveState
+  const {
+    activeLayers,
+    activeStep,
+    realToScreen,
+    onObjectClicked,
+    setHoverTooltip,
+  } = interactiveState
   const {
     points,
     layer,
@@ -62,6 +66,26 @@ export const Line = ({
   }, [hoverRadius, mousePosition, screenPoints])
 
   const baseColor = strokeColor ?? defaultColors[index % defaultColors.length]
+
+  useEffect(() => {
+    if (!isHovered || !line.label || !mousePosition) return
+
+    setHoverTooltip?.({
+      text: line.label,
+      x: mousePosition.x,
+      y: mousePosition.y,
+    })
+
+    return () => {
+      setHoverTooltip?.(null)
+    }
+  }, [
+    isHovered,
+    line.label,
+    mousePosition?.x,
+    mousePosition?.y,
+    setHoverTooltip,
+  ])
 
   return (
     <div
@@ -118,19 +142,6 @@ export const Line = ({
           pointerEvents="none"
         />
       </svg>
-      {isHovered && line.label && mousePosition && (
-        <div
-          style={{
-            position: "absolute",
-            left: mousePosition.x,
-            top: mousePosition.y - 8,
-            transform: "translate(-50%, -100%)",
-            pointerEvents: "none",
-          }}
-        >
-          <Tooltip text={line.label} />
-        </div>
-      )}
     </div>
   )
 }

--- a/site/components/InteractiveGraphics/Point.tsx
+++ b/site/components/InteractiveGraphics/Point.tsx
@@ -1,8 +1,7 @@
 import type * as Types from "lib/types"
 import { applyToPoint } from "transformation-matrix"
 import type { InteractiveState } from "./InteractiveState"
-import { useState } from "react"
-import { Tooltip } from "./Tooltip"
+import { useEffect, useState } from "react"
 import { defaultColors } from "./defaultColors"
 import { safeLighten } from "site/utils/safeLighten"
 
@@ -16,12 +15,32 @@ export const Point = ({
   index: number
 }) => {
   const { color, label, layer, step } = point
-  const { activeLayers, activeStep, realToScreen, onObjectClicked } =
-    interactiveState
+  const {
+    activeLayers,
+    activeStep,
+    realToScreen,
+    onObjectClicked,
+    setHoverTooltip,
+  } = interactiveState
   const [isHovered, setIsHovered] = useState(false)
 
   const screenPoint = applyToPoint(realToScreen, point)
   const size = 10
+  const tooltipText = `${label ? `${label}\n` : ""}x: ${point.x.toFixed(2)}, y: ${point.y.toFixed(2)}`
+
+  useEffect(() => {
+    if (!isHovered) return
+
+    setHoverTooltip?.({
+      text: tooltipText,
+      x: screenPoint.x,
+      y: screenPoint.y - size / 2,
+    })
+
+    return () => {
+      setHoverTooltip?.(null)
+    }
+  }, [isHovered, screenPoint.x, screenPoint.y, setHoverTooltip, tooltipText])
 
   return (
     <div
@@ -44,7 +63,10 @@ export const Point = ({
         transition: "border-color 0.2s",
       }}
       onMouseEnter={() => setIsHovered(true)}
-      onMouseLeave={() => setIsHovered(false)}
+      onMouseLeave={() => {
+        setIsHovered(false)
+        setHoverTooltip?.(null)
+      }}
       onClick={() =>
         onObjectClicked?.({
           type: "point",
@@ -52,22 +74,6 @@ export const Point = ({
           object: point,
         })
       }
-    >
-      {isHovered && (
-        <div
-          style={{
-            position: "absolute",
-            bottom: "100%",
-            left: "50%",
-            transform: "translateX(-50%)",
-            marginBottom: 8,
-          }}
-        >
-          <Tooltip
-            text={`${label ? `${label}\n` : ""}x: ${point.x.toFixed(2)}, y: ${point.y.toFixed(2)}`}
-          />
-        </div>
-      )}
-    </div>
+    ></div>
   )
 }

--- a/site/components/InteractiveGraphics/Polygon.tsx
+++ b/site/components/InteractiveGraphics/Polygon.tsx
@@ -5,6 +5,7 @@ import { applyToPoint } from "transformation-matrix"
 import type { InteractiveState } from "./InteractiveState"
 import { Tooltip } from "./Tooltip"
 import { defaultColors } from "./defaultColors"
+import { tooltipLayerZIndex } from "./tooltipLayer"
 
 export const Polygon = ({
   polygon,
@@ -92,6 +93,7 @@ export const Polygon = ({
             transform: "translateX(-50%)",
             marginBottom: 8,
             pointerEvents: "none",
+            zIndex: tooltipLayerZIndex,
           }}
         >
           <Tooltip text={polygon.label} />

--- a/site/components/InteractiveGraphics/Polygon.tsx
+++ b/site/components/InteractiveGraphics/Polygon.tsx
@@ -1,11 +1,9 @@
 import type * as Types from "lib/types"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { safeLighten } from "site/utils/safeLighten"
 import { applyToPoint } from "transformation-matrix"
 import type { InteractiveState } from "./InteractiveState"
-import { Tooltip } from "./Tooltip"
 import { defaultColors } from "./defaultColors"
-import { tooltipLayerZIndex } from "./tooltipLayer"
 
 export const Polygon = ({
   polygon,
@@ -17,18 +15,19 @@ export const Polygon = ({
   index: number
 }) => {
   const { points, fill, stroke, strokeWidth } = polygon
-  const { realToScreen, onObjectClicked } = interactiveState
+  const { realToScreen, onObjectClicked, setHoverTooltip } = interactiveState
   const [isHovered, setIsHovered] = useState(false)
 
-  if (!points || points.length === 0) return null
-
-  const screenPoints = points.map((p) => applyToPoint(realToScreen, p))
+  const hasPoints = Boolean(points && points.length > 0)
+  const screenPoints = hasPoints
+    ? points.map((p) => applyToPoint(realToScreen, p))
+    : []
   const xs = screenPoints.map((p) => p.x)
   const ys = screenPoints.map((p) => p.y)
-  const minX = Math.min(...xs)
-  const maxX = Math.max(...xs)
-  const minY = Math.min(...ys)
-  const maxY = Math.max(...ys)
+  const minX = hasPoints ? Math.min(...xs) : 0
+  const maxX = hasPoints ? Math.max(...xs) : 0
+  const minY = hasPoints ? Math.min(...ys) : 0
+  const maxY = hasPoints ? Math.max(...ys) : 0
   const padding = 4
 
   const svgLeft = minX - padding
@@ -55,6 +54,22 @@ export const Polygon = ({
   const screenStrokeWidth =
     strokeWidth === undefined ? undefined : strokeWidth * realToScreen.a
 
+  useEffect(() => {
+    if (!hasPoints || !isHovered || !polygon.label) return
+
+    setHoverTooltip?.({
+      text: polygon.label,
+      x: (minX + maxX) / 2,
+      y: svgTop,
+    })
+
+    return () => {
+      setHoverTooltip?.(null)
+    }
+  }, [hasPoints, isHovered, maxX, minX, polygon.label, setHoverTooltip, svgTop])
+
+  if (!hasPoints) return null
+
   return (
     <div
       style={{
@@ -74,7 +89,10 @@ export const Polygon = ({
           strokeWidth={screenStrokeWidth}
           pointerEvents="all"
           onMouseEnter={() => setIsHovered(true)}
-          onMouseLeave={() => setIsHovered(false)}
+          onMouseLeave={() => {
+            setIsHovered(false)
+            setHoverTooltip?.(null)
+          }}
           onClick={() =>
             onObjectClicked?.({
               type: "polygon",
@@ -84,21 +102,6 @@ export const Polygon = ({
           }
         />
       </svg>
-      {isHovered && polygon.label && (
-        <div
-          style={{
-            position: "absolute",
-            bottom: "100%",
-            left: "50%",
-            transform: "translateX(-50%)",
-            marginBottom: 8,
-            pointerEvents: "none",
-            zIndex: tooltipLayerZIndex,
-          }}
-        >
-          <Tooltip text={polygon.label} />
-        </div>
-      )}
     </div>
   )
 }

--- a/site/components/InteractiveGraphics/Rect.tsx
+++ b/site/components/InteractiveGraphics/Rect.tsx
@@ -4,6 +4,7 @@ import type { InteractiveState } from "./InteractiveState"
 import { useState } from "react"
 import { Tooltip } from "./Tooltip"
 import { defaultColors } from "./defaultColors"
+import { tooltipLayerZIndex } from "./tooltipLayer"
 import { safeLighten } from "site/utils/safeLighten"
 
 export const Rect = ({
@@ -42,6 +43,7 @@ export const Rect = ({
         height: projectedRect.height,
         transform: "translate(-50%, -50%)",
         pointerEvents: "none",
+        zIndex: isHovered ? tooltipLayerZIndex : undefined,
       }}
     >
       <div
@@ -78,6 +80,7 @@ export const Rect = ({
             transform: "translateX(-50%)",
             marginBottom: 8,
             pointerEvents: "none",
+            zIndex: tooltipLayerZIndex,
           }}
         >
           <Tooltip text={rect.label} />

--- a/site/components/InteractiveGraphics/Rect.tsx
+++ b/site/components/InteractiveGraphics/Rect.tsx
@@ -1,10 +1,8 @@
 import type * as Types from "lib/types"
 import { getProjectedRectGeometry } from "lib/rectGeometry"
 import type { InteractiveState } from "./InteractiveState"
-import { useState } from "react"
-import { Tooltip } from "./Tooltip"
+import { useEffect, useState } from "react"
 import { defaultColors } from "./defaultColors"
-import { tooltipLayerZIndex } from "./tooltipLayer"
 import { safeLighten } from "site/utils/safeLighten"
 
 export const Rect = ({
@@ -18,8 +16,13 @@ export const Rect = ({
 }) => {
   const defaultColor = defaultColors[index % defaultColors.length]
   let { fill, stroke } = rect
-  const { activeLayers, activeStep, realToScreen, onObjectClicked } =
-    interactiveState
+  const {
+    activeLayers,
+    activeStep,
+    realToScreen,
+    onObjectClicked,
+    setHoverTooltip,
+  } = interactiveState
   const [isHovered, setIsHovered] = useState(false)
 
   const projectedRect = getProjectedRectGeometry(rect, realToScreen)
@@ -33,6 +36,27 @@ export const Rect = ({
     stroke = safeLighten(0.2, stroke!)
   }
 
+  useEffect(() => {
+    if (!isHovered || !rect.label) return
+
+    setHoverTooltip?.({
+      text: rect.label,
+      x: projectedRect.center.x,
+      y: projectedRect.center.y - projectedRect.height / 2,
+    })
+
+    return () => {
+      setHoverTooltip?.(null)
+    }
+  }, [
+    isHovered,
+    projectedRect.center.x,
+    projectedRect.center.y,
+    projectedRect.height,
+    rect.label,
+    setHoverTooltip,
+  ])
+
   return (
     <div
       style={{
@@ -43,7 +67,6 @@ export const Rect = ({
         height: projectedRect.height,
         transform: "translate(-50%, -50%)",
         pointerEvents: "none",
-        zIndex: isHovered ? tooltipLayerZIndex : undefined,
       }}
     >
       <div
@@ -62,7 +85,10 @@ export const Rect = ({
           pointerEvents: "auto",
         }}
         onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
+        onMouseLeave={() => {
+          setIsHovered(false)
+          setHoverTooltip?.(null)
+        }}
         onClick={() =>
           onObjectClicked?.({
             type: "rect",
@@ -71,21 +97,6 @@ export const Rect = ({
           })
         }
       />
-      {isHovered && rect.label && (
-        <div
-          style={{
-            position: "absolute",
-            bottom: "100%",
-            left: "50%",
-            transform: "translateX(-50%)",
-            marginBottom: 8,
-            pointerEvents: "none",
-            zIndex: tooltipLayerZIndex,
-          }}
-        >
-          <Tooltip text={rect.label} />
-        </div>
-      )}
     </div>
   )
 }

--- a/site/components/InteractiveGraphics/tooltipLayer.ts
+++ b/site/components/InteractiveGraphics/tooltipLayer.ts
@@ -1,0 +1,1 @@
+export const tooltipLayerZIndex = 1000


### PR DESCRIPTION
## Summary
- Raise rect and polygon hover label boxes into a shared overlay layer so they render above overlapping graphics.
- Apply the same z-index to the hovered rect container to avoid stacking-context issues.
- Add a shared tooltip layer constant for the interactive graphics components.

## Testing
- Unit tests passed across the graphics suite.
- Local build completed successfully.
- Interactive formatting checks passed.