### PR TITLE
Apply objectLimit globally after filtering

### DIFF
--- a/site/components/InteractiveGraphics/InteractiveGraphics.tsx
+++ b/site/components/InteractiveGraphics/InteractiveGraphics.tsx
@@ -1,7 +1,10 @@
 import useResizeObserver from "@react-hook/resize-observer"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { SuperGrid } from "react-supergrid"
-import { applyObjectLimit } from "site/utils/applyObjectLimit"
+import {
+  applyObjectLimit,
+  normalizeObjectLimit,
+} from "site/utils/applyObjectLimit"
 import { getGraphicsBounds } from "site/utils/getGraphicsBounds"
 import { getMaxStep } from "site/utils/getMaxStep"
 import { sortRectsByArea } from "site/utils/sortRectsByArea"
@@ -507,8 +510,10 @@ export const InteractiveGraphics = ({
     preLimitCircles.length +
     preLimitTexts.length +
     preLimitArrows.length
+  const normalizedObjectLimit = normalizeObjectLimit(objectLimit)
   const isLimitReached =
-    objectLimit !== undefined && totalFilteredObjects > objectLimit
+    normalizedObjectLimit !== undefined &&
+    totalFilteredObjects > normalizedObjectLimit
 
   const {
     arrows: filteredArrows,
@@ -594,7 +599,7 @@ export const InteractiveGraphics = ({
               </label>
               {isLimitReached && (
                 <span style={{ color: "red", fontSize: "12px" }}>
-                  Display limited to {objectLimit} objects. Received:{" "}
+                  Display limited to {normalizedObjectLimit} objects. Received:{" "}
                   {totalFilteredObjects}.
                 </span>
               )}

--- a/site/components/InteractiveGraphics/InteractiveGraphics.tsx
+++ b/site/components/InteractiveGraphics/InteractiveGraphics.tsx
@@ -1,6 +1,7 @@
 import useResizeObserver from "@react-hook/resize-observer"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { SuperGrid } from "react-supergrid"
+import { applyObjectLimit } from "site/utils/applyObjectLimit"
 import { getGraphicsBounds } from "site/utils/getGraphicsBounds"
 import { getMaxStep } from "site/utils/getMaxStep"
 import { sortRectsByArea } from "site/utils/sortRectsByArea"
@@ -421,65 +422,104 @@ export const InteractiveGraphics = ({
     filterLayerAndStep,
   })
 
-  const filterAndLimit = <T,>(
+  const filterObjects = <T,>(
     objects: T[] | undefined,
     filterFn: (obj: T) => boolean,
   ): (T & { originalIndex: number })[] => {
     if (!objects) return []
-    const filtered = objects
+    return objects
       .map((obj, index) => ({ ...obj, originalIndex: index }))
       .filter(filterFn)
-    return objectLimit ? filtered.slice(-objectLimit) : filtered
   }
 
-  const filteredLines = useMemo(
+  const preLimitLines = useMemo(
     () =>
-      filterAndLimit(graphics.lines, filterLines).sort(
+      filterObjects(graphics.lines, filterLines).sort(
         (a, b) =>
           (a.zIndex ?? 0) - (b.zIndex ?? 0) ||
           a.originalIndex - b.originalIndex,
       ),
-    [graphics.lines, filterLines, objectLimit],
+    [graphics.lines, filterLines],
   )
-  const filteredInfiniteLines = useMemo(
-    () => filterAndLimit(graphics.infiniteLines, filterLayerAndStep),
-    [graphics.infiniteLines, filterLayerAndStep, objectLimit],
+  const preLimitInfiniteLines = useMemo(
+    () => filterObjects(graphics.infiniteLines, filterLayerAndStep),
+    [graphics.infiniteLines, filterLayerAndStep],
   )
-  const filteredRects = useMemo(
-    () => sortRectsByArea(filterAndLimit(graphics.rects, filterRects)),
-    [graphics.rects, filterRects, objectLimit],
+  const preLimitRects = useMemo(
+    () => sortRectsByArea(filterObjects(graphics.rects, filterRects)),
+    [graphics.rects, filterRects],
   )
-  const filteredPolygons = useMemo(
-    () => filterAndLimit(graphics.polygons, filterPolygons),
-    [graphics.polygons, filterPolygons, objectLimit],
+  const preLimitPolygons = useMemo(
+    () => filterObjects(graphics.polygons, filterPolygons),
+    [graphics.polygons, filterPolygons],
   )
-  const filteredPoints = useMemo(
-    () => filterAndLimit(graphics.points, filterPoints),
-    [graphics.points, filterPoints, objectLimit],
+  const preLimitPoints = useMemo(
+    () => filterObjects(graphics.points, filterPoints),
+    [graphics.points, filterPoints],
   )
-  const filteredCircles = useMemo(
-    () => filterAndLimit(graphics.circles, filterCircles),
-    [graphics.circles, filterCircles, objectLimit],
+  const preLimitCircles = useMemo(
+    () => filterObjects(graphics.circles, filterCircles),
+    [graphics.circles, filterCircles],
   )
-  const filteredTexts = useMemo(
-    () => filterAndLimit(graphics.texts, filterTexts),
-    [graphics.texts, filterTexts, objectLimit],
+  const preLimitTexts = useMemo(
+    () => filterObjects(graphics.texts, filterTexts),
+    [graphics.texts, filterTexts],
   )
-  const filteredArrows = useMemo(
-    () => filterAndLimit(graphics.arrows, filterArrows),
-    [graphics.arrows, filterArrows, objectLimit],
+  const preLimitArrows = useMemo(
+    () => filterObjects(graphics.arrows, filterArrows),
+    [graphics.arrows, filterArrows],
+  )
+
+  const limitedObjects = useMemo(
+    () =>
+      applyObjectLimit(
+        {
+          arrows: preLimitArrows,
+          infiniteLines: preLimitInfiniteLines,
+          lines: preLimitLines,
+          rects: preLimitRects,
+          polygons: preLimitPolygons,
+          circles: preLimitCircles,
+          texts: preLimitTexts,
+          points: preLimitPoints,
+        },
+        objectLimit,
+      ),
+    [
+      preLimitArrows,
+      preLimitInfiniteLines,
+      preLimitLines,
+      preLimitRects,
+      preLimitPolygons,
+      preLimitCircles,
+      preLimitTexts,
+      preLimitPoints,
+      objectLimit,
+    ],
   )
 
   const totalFilteredObjects =
-    filteredInfiniteLines.length +
-    filteredLines.length +
-    filteredRects.length +
-    filteredPolygons.length +
-    filteredPoints.length +
-    filteredCircles.length +
-    filteredTexts.length +
-    filteredArrows.length
-  const isLimitReached = objectLimit && totalFilteredObjects > objectLimit
+    preLimitInfiniteLines.length +
+    preLimitLines.length +
+    preLimitRects.length +
+    preLimitPolygons.length +
+    preLimitPoints.length +
+    preLimitCircles.length +
+    preLimitTexts.length +
+    preLimitArrows.length
+  const isLimitReached =
+    objectLimit !== undefined && totalFilteredObjects > objectLimit
+
+  const {
+    arrows: filteredArrows,
+    infiniteLines: filteredInfiniteLines,
+    lines: filteredLines,
+    rects: filteredRects,
+    polygons: filteredPolygons,
+    circles: filteredCircles,
+    texts: filteredTexts,
+    points: filteredPoints,
+  } = limitedObjects
 
   return (
     <div>

--- a/site/utils/applyObjectLimit.ts
+++ b/site/utils/applyObjectLimit.ts
@@ -1,0 +1,29 @@
+type ObjectGroups = Record<string, readonly unknown[]>
+
+export const applyObjectLimit = <TGroups extends ObjectGroups>(
+  groups: TGroups,
+  objectLimit?: number,
+): TGroups => {
+  if (objectLimit === undefined) {
+    return groups
+  }
+
+  const limit = Math.max(0, objectLimit)
+  let remaining = limit
+  const entries = Object.entries(groups) as [
+    keyof TGroups,
+    TGroups[keyof TGroups],
+  ][]
+  const limitedGroups = {} as TGroups
+
+  for (let index = entries.length - 1; index >= 0; index--) {
+    const [key, objects] = entries[index]
+    const keepCount = Math.min(objects.length, remaining)
+    limitedGroups[key] = objects.slice(
+      objects.length - keepCount,
+    ) as TGroups[typeof key]
+    remaining -= keepCount
+  }
+
+  return limitedGroups
+}

--- a/site/utils/applyObjectLimit.ts
+++ b/site/utils/applyObjectLimit.ts
@@ -21,7 +21,7 @@ export const applyObjectLimit = <TGroups extends ObjectGroups>(
     const keepCount = Math.min(objects.length, remaining)
     limitedGroups[key] = objects.slice(
       objects.length - keepCount,
-    ) as TGroups[typeof key]
+    ) as unknown as TGroups[typeof key]
     remaining -= keepCount
   }
 

--- a/site/utils/applyObjectLimit.ts
+++ b/site/utils/applyObjectLimit.ts
@@ -1,14 +1,24 @@
 type ObjectGroups = Record<string, readonly unknown[]>
 
+export const normalizeObjectLimit = (
+  objectLimit?: number,
+): number | undefined => {
+  if (objectLimit === undefined || !Number.isFinite(objectLimit)) {
+    return undefined
+  }
+
+  return Math.max(0, Math.floor(objectLimit))
+}
+
 export const applyObjectLimit = <TGroups extends ObjectGroups>(
   groups: TGroups,
   objectLimit?: number,
 ): TGroups => {
-  if (objectLimit === undefined) {
+  const limit = normalizeObjectLimit(objectLimit)
+  if (limit === undefined) {
     return groups
   }
 
-  const limit = Math.max(0, objectLimit)
   let remaining = limit
   const entries = Object.entries(groups) as [
     keyof TGroups,

--- a/tests/apply-object-limit.test.ts
+++ b/tests/apply-object-limit.test.ts
@@ -42,4 +42,53 @@ describe("applyObjectLimit", () => {
       points: [],
     })
   })
+
+  test("carries unused budget to earlier groups", () => {
+    const limited = applyObjectLimit(
+      {
+        lines: ["line-1", "line-2"],
+        rects: ["rect-1"],
+        points: [],
+      },
+      2,
+    )
+
+    expect(limited).toEqual({
+      lines: ["line-2"],
+      rects: ["rect-1"],
+      points: [],
+    })
+  })
+
+  test("preserves every group key after the budget is consumed", () => {
+    const limited = applyObjectLimit(
+      {
+        lines: ["line-1"],
+        rects: ["rect-1"],
+        points: ["point-1"],
+      },
+      1,
+    )
+
+    expect(limited).toEqual({
+      lines: [],
+      rects: [],
+      points: ["point-1"],
+    })
+  })
+
+  test("treats negative limits as zero", () => {
+    expect(
+      applyObjectLimit(
+        {
+          lines: ["line-1"],
+          points: ["point-1"],
+        },
+        -1,
+      ),
+    ).toEqual({
+      lines: [],
+      points: [],
+    })
+  })
 })

--- a/tests/apply-object-limit.test.ts
+++ b/tests/apply-object-limit.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test"
+import { applyObjectLimit } from "site/utils/applyObjectLimit"
+
+describe("applyObjectLimit", () => {
+  test("applies one shared limit across object groups", () => {
+    const limited = applyObjectLimit(
+      {
+        lines: ["line-1", "line-2"],
+        rects: ["rect-1", "rect-2"],
+        points: ["point-1", "point-2"],
+      },
+      3,
+    )
+
+    expect(limited).toEqual({
+      lines: [],
+      rects: ["rect-2"],
+      points: ["point-1", "point-2"],
+    })
+  })
+
+  test("returns filtered groups unchanged when no limit is set", () => {
+    const groups = {
+      lines: ["line-1"],
+      points: ["point-1", "point-2"],
+    }
+
+    expect(applyObjectLimit(groups)).toBe(groups)
+  })
+
+  test("supports an explicit zero-object limit", () => {
+    expect(
+      applyObjectLimit(
+        {
+          lines: ["line-1"],
+          points: ["point-1"],
+        },
+        0,
+      ),
+    ).toEqual({
+      lines: [],
+      points: [],
+    })
+  })
+})

--- a/tests/apply-object-limit.test.ts
+++ b/tests/apply-object-limit.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test"
-import { applyObjectLimit } from "site/utils/applyObjectLimit"
+import {
+  applyObjectLimit,
+  normalizeObjectLimit,
+} from "site/utils/applyObjectLimit"
 
 describe("applyObjectLimit", () => {
   test("applies one shared limit across object groups", () => {
@@ -90,5 +93,38 @@ describe("applyObjectLimit", () => {
       lines: [],
       points: [],
     })
+  })
+
+  test("floors fractional limits before slicing groups", () => {
+    expect(
+      applyObjectLimit(
+        {
+          lines: ["line-1", "line-2"],
+          points: ["point-1", "point-2"],
+        },
+        2.9,
+      ),
+    ).toEqual({
+      lines: [],
+      points: ["point-1", "point-2"],
+    })
+  })
+
+  test("ignores non-finite limits", () => {
+    const groups = {
+      lines: ["line-1"],
+      points: ["point-1"],
+    }
+
+    expect(applyObjectLimit(groups, Number.NaN)).toBe(groups)
+    expect(applyObjectLimit(groups, Number.POSITIVE_INFINITY)).toBe(groups)
+  })
+
+  test("normalizes finite limits for UI messages", () => {
+    expect(normalizeObjectLimit(undefined)).toBeUndefined()
+    expect(normalizeObjectLimit(Number.NaN)).toBeUndefined()
+    expect(normalizeObjectLimit(Number.POSITIVE_INFINITY)).toBeUndefined()
+    expect(normalizeObjectLimit(-4)).toBe(0)
+    expect(normalizeObjectLimit(3.9)).toBe(3)
   })
 })


### PR DESCRIPTION
/claim #42

## Summary
- filters each InteractiveGraphics object bucket first, then applies one shared objectLimit across all rendered object groups
- keeps the warning count based on the pre-limit filtered object total
- adds a focused unit-tested helper for the global limiter

## Verification
- `bun test tests/apply-object-limit.test.ts`
- `bun test tests/mergeGraphics.test.ts`
- `bun test`
- `bunx biome check site/utils/applyObjectLimit.ts site/components/InteractiveGraphics/InteractiveGraphics.tsx tests/apply-object-limit.test.ts`
- `bunx tsc --noEmit`
- `bun run build`
- `bun run vercel-build`
- `git diff --check`

## Notes
The patch keeps existing per-bucket filtering and sorting behavior, but moves limiting to a single post-filter cap so objectLimit={3} cannot render more than three total graphics objects across buckets.